### PR TITLE
Compare DataColumn Details

### DIFF
--- a/Compare-NET-Objects-Tests/Compare-NET-Objects-Tests.csproj
+++ b/Compare-NET-Objects-Tests/Compare-NET-Objects-Tests.csproj
@@ -66,6 +66,7 @@
     <Compile Include="BugTests.cs" />
     <Compile Include="Common.cs" />
     <Compile Include="CompareClassTests.cs" />
+    <Compile Include="CompareDataColumnTests.cs" />
     <Compile Include="CompareDataRowTests.cs" />
     <Compile Include="CompareDatasetTests.cs" />
     <Compile Include="CompareDataTableTests.cs" />

--- a/Compare-NET-Objects-Tests/CompareDataColumnTests.cs
+++ b/Compare-NET-Objects-Tests/CompareDataColumnTests.cs
@@ -1,0 +1,91 @@
+﻿using System.Data;
+using KellermanSoftware.CompareNetObjects;
+using NUnit.Framework;
+
+namespace KellermanSoftware.CompareNetObjectsTests
+{
+    [TestFixture]
+    public class CompareDataColumnTests
+    {
+        #region Class Variables
+        private CompareLogic _compare;
+        #endregion
+
+        #region Setup/Teardown
+
+        /// <summary>
+        /// Code that is run once for a suite of tests
+        /// </summary>
+        [TestFixtureSetUp]
+        public void TestFixtureSetup()
+        {
+
+        }
+
+        /// <summary>
+        /// Code that is run once after a suite of tests has finished executing
+        /// </summary>
+        [TestFixtureTearDown]
+        public void TestFixtureTearDown()
+        {
+
+        }
+
+        /// <summary>
+        /// Code that is run before each test
+        /// </summary>
+        [SetUp]
+        public void Initialize()
+        {
+            _compare = new CompareLogic();
+        }
+
+        /// <summary>
+        /// Code that is run after each test
+        /// </summary>
+        [TearDown]
+        public void Cleanup()
+        {
+            _compare = null;
+        }
+        #endregion
+
+        #region Tests
+        [Test]
+        public void DataColumnPositiveTest()
+        {
+            var dc1 = new DataColumn("Flavor", typeof(string));
+            var dc2 = new DataColumn("Flavor", typeof(string));
+            Assert.IsTrue(_compare.Compare(dc1, dc2).AreEqual);
+        }
+
+        [Test]
+        public void DataColumnMismatchedNameTest()
+        {
+            var dc1 = new DataColumn("Flavor", typeof(string));
+            var dc2 = new DataColumn("Flavour", typeof(string));
+            var result = _compare.Compare(dc1, dc2);
+            Assert.IsFalse(result.AreEqual);
+
+            Assert.AreEqual(1, result.Differences.Count);
+
+            Assert.AreEqual("Flavor", result.Differences[0].Object1Value);
+            Assert.AreEqual("Flavour", result.Differences[0].Object2Value);
+        }
+
+        [Test]
+        public void DataColumnMismatchedTypeTest()
+        {
+            var dc1 = new DataColumn("Price", typeof(string));
+            var dc2 = new DataColumn("Price", typeof(decimal));
+            var result = _compare.Compare(dc1, dc2);
+            Assert.IsFalse(result.AreEqual);
+
+            Assert.AreEqual(1, result.Differences.Count);
+
+            Assert.AreEqual("System.String", result.Differences[0].Object1Value);
+            Assert.AreEqual("System.Decimal", result.Differences[0].Object2Value);
+        }
+        #endregion
+    }
+}

--- a/Compare-NET-Objects-Tests/CompareDataTableTests.cs
+++ b/Compare-NET-Objects-Tests/CompareDataTableTests.cs
@@ -59,6 +59,25 @@ namespace KellermanSoftware.CompareNetObjectsTests
             ds2.Tables[0].Rows[2][0] = "Chunky Chocolate Heaven";
             Assert.IsFalse(_compare.Compare(ds1.Tables[0], ds2.Tables[0]).AreEqual);
         }
+
+        [Test]
+        public void DataTableNegativeColumnNameTest()
+        {
+            DataSet ds1 = CreateMockDataset();
+            DataSet ds2 = Common.CloneWithSerialization(ds1);
+            ds2.Tables[0].Columns[0].ColumnName = "Flavour";
+            Assert.IsFalse(_compare.Compare(ds1.Tables[0], ds2.Tables[0]).AreEqual);
+        }
+
+        [Test]
+        public void DataTableNegativeMultipleColumnNameTest()
+        {
+            DataSet ds1 = CreateMockDataset();
+            DataSet ds2 = Common.CloneWithSerialization(ds1);
+            ds2.Tables[0].Columns[0].ColumnName = "Flavour";
+            ds2.Tables[0].Columns[1].ColumnName = "Prix";
+            Assert.IsFalse(_compare.Compare(ds1.Tables[0], ds2.Tables[0]).AreEqual);
+        }
         #endregion
 
         #region Supporting Methods

--- a/Compare-NET-Objects-Tests/CompareDatasetTests.cs
+++ b/Compare-NET-Objects-Tests/CompareDatasetTests.cs
@@ -69,7 +69,7 @@ namespace KellermanSoftware.CompareNetObjectsTests
         }
 
         [Test]
-        public void DatasetNegativeColumnTest()
+        public void DatasetNegativeColumnCountTest()
         {
             DataSet ds1 = CreateMockDataset();
             DataSet ds2 = Common.CloneWithSerialization(ds1);

--- a/Compare-NET-Objects/TypeComparers/DataTableComparer.cs
+++ b/Compare-NET-Objects/TypeComparers/DataTableComparer.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Data;
 using System.Globalization;
-
+using System.Linq;
 
 namespace KellermanSoftware.CompareNetObjects.TypeComparers
 {
@@ -71,12 +71,12 @@ namespace KellermanSoftware.CompareNetObjects.TypeComparers
                     return;
             }
 
-            if (ColumnCountsDifferent(parms)) return;
+            if (ColumnsDifferent(parms)) return;
 
             CompareEachRow(parms);
         }
 
-        private bool ColumnCountsDifferent(CompareParms parms)
+        private bool ColumnsDifferent(CompareParms parms)
         {
             DataTable dataTable1 = parms.Object1 as DataTable;
             DataTable dataTable2 = parms.Object2 as DataTable;
@@ -106,6 +106,28 @@ namespace KellermanSoftware.CompareNetObjects.TypeComparers
                 if (parms.Result.ExceededDifferences)
                     return true;
             }
+
+            foreach (var i in Enumerable.Range(0, dataTable1.Columns.Count))
+            {
+                string currentBreadCrumb = AddBreadCrumb(parms.Config, parms.BreadCrumb, "Columns", string.Empty, i);
+
+                CompareParms childParms = new CompareParms
+                {
+                    Result = parms.Result,
+                    Config = parms.Config,
+                    ParentObject1 = parms.Object1,
+                    ParentObject2 = parms.Object2,
+                    Object1 = dataTable1.Columns[i],
+                    Object2 = dataTable2.Columns[i],
+                    BreadCrumb = currentBreadCrumb
+                };
+
+                RootComparer.Compare(childParms);
+
+                if (parms.Result.ExceededDifferences)
+                    return true;
+            }
+
             return false;
         }
 


### PR DESCRIPTION
Added some comparison tests around DataColumn. Did not appear necessary
to add a specific 'DataColumnComparer' implementation.

Updated DataTableComparer to compare column details in addition to
column count.
