### PR TITLE
Allowing collection matching specification to be defined on an interface

### DIFF
--- a/Compare-NET-Objects-Tests/IgnoreOrderTests.cs
+++ b/Compare-NET-Objects-Tests/IgnoreOrderTests.cs
@@ -1020,6 +1020,80 @@ namespace KellermanSoftware.CompareNetObjectsTests
             Assert.IsTrue(result.Differences.Where(d => d.Object1Value == "(null)" || d.Object2Value == "(null)").ToArray().Length == 0);
 
         }
+
+        [Test]
+        public void CollectionMatchingSpecBasedOnInterfaceTest()
+        {
+            IEntity entityToModify = new Entity {Id = 101, Description = "Desription 2"};
+            IEntity entity1 = new Entity
+            {
+                Id = 1,
+                Children = new List<IEntity>
+                {
+                    new Entity
+                    {
+                        Id = 10,
+                        Children = new List<IEntity>
+                        {
+                            new Entity {Id = 100, Description = "Description 1"}
+                        }
+                    },
+                    new Entity
+                    {
+                        Id = 11,
+                        Children = new List<IEntity>
+                        {
+                            entityToModify,
+                            new Entity {Id = 102, Description = "Description 3"}
+                        }
+                    }
+
+                }
+            };
+            IEntity newlyAddedEntity = new Entity {Id = 103, Description = "Description 4"};
+            IEntity modifiedEntity = new Entity {Id = 101, Description = "Desription 5"};
+            IEntity entity2 = new Entity
+            {
+                Id = 1,
+                Children = new List<IEntity>
+                {
+                    new Entity
+                    {
+                        Id = 10,
+                        Children = new List<IEntity>
+                        {
+                            new Entity {Id = 100, Description = "Description 1"},
+                            newlyAddedEntity
+                        }
+                    },
+                    new Entity
+                    {
+                        Id = 11,
+                        Children = new List<IEntity>
+                        {
+                            new Entity {Id = 102, Description = "Description 3"},
+                            modifiedEntity
+                        }
+                    }
+
+                }
+            };
+
+            ComparisonConfig config = new ComparisonConfig
+            {
+                IgnoreCollectionOrder = true,
+                MaxDifferences = int.MaxValue,
+                CollectionMatchingSpec = new Dictionary<Type, IEnumerable<string>> { { typeof(IEntity), new string[] { "Id" } } }
+            };
+            _compare.Config = config;
+
+            var result = _compare.Compare(entity1, entity2);
+            Assert.AreEqual(result.Differences.Count, 3);
+            Assert.AreEqual(result.Differences[0].PropertyName, ".Children[Id:10].Children");
+            Assert.AreEqual(result.Differences[1].PropertyName, ".Children[Id:10].Children[Id:103]");
+            Assert.AreEqual(result.Differences[2].PropertyName, ".Children[Id:11].Children[Id:101].Description");
+        }
+
         #endregion
     }
 }

--- a/Compare-NET-Objects-Tests/TestClasses/Entity.cs
+++ b/Compare-NET-Objects-Tests/TestClasses/Entity.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace KellermanSoftware.CompareNetObjectsTests.TestClasses
 {
-    public enum Level 
+    public enum Level
     {
         Company,
         Division,
@@ -38,6 +38,12 @@ namespace KellermanSoftware.CompareNetObjectsTests.TestClasses
         {
             get { return _children; }
             set { _children = value; }
+        }
+
+        public int Id
+        {
+            get;
+            set;
         }
 
         //can be circular refs, so bye bye for now

--- a/Compare-NET-Objects-Tests/TestClasses/IEntity.cs
+++ b/Compare-NET-Objects-Tests/TestClasses/IEntity.cs
@@ -29,5 +29,11 @@ namespace KellermanSoftware.CompareNetObjectsTests.TestClasses
             get;
             set;
         }
+
+        int Id
+        {
+            get;
+            set;
+        }
     }
 }

--- a/Compare-NET-Objects/IgnoreOrderTypes/IgnoreOrderLogic.cs
+++ b/Compare-NET-Objects/IgnoreOrderTypes/IgnoreOrderLogic.cs
@@ -264,11 +264,18 @@ namespace KellermanSoftware.CompareNetObjects.IgnoreOrderTypes
                 return result.Config.CollectionMatchingSpec.First(p => p.Key == type).Value.ToList();
             }
 
+            Type[] typeInterfaces = type.GetInterfaces();
+            bool matchingInterfacePresent = result.Config.CollectionMatchingSpec.Keys.Any(k => typeInterfaces.Any(t => t == k));
+            if (matchingInterfacePresent)
+            {
+                return result.Config.CollectionMatchingSpec.First(p => typeInterfaces.Contains(p.Key)).Value.ToList();
+            }
+
             //Make a key out of primative types, date, decimal, string, guid, and enum of the class
             List<string> list = Cache.GetPropertyInfo(result, type)
                 .Where(o => o.CanWrite && (TypeHelper.IsSimpleType(o.PropertyType) || TypeHelper.IsEnum(o.PropertyType)))
                 .Select(o => o.Name).ToList();
-
+            
             //Remove members to ignore in the key
             foreach (var member in result.Config.MembersToIgnore)
             {


### PR DESCRIPTION
This change allows for the collection matching spec to be based on an interface's property, rather than just a property in a class. Please let me know if I haven't adhered to the project's coding guidelines in anyway. Thank you.