### PR TITLE
fix comparison of decimals when ignore collection order

### DIFF
--- a/Compare-NET-Objects-Tests/BugTests.cs
+++ b/Compare-NET-Objects-Tests/BugTests.cs
@@ -264,6 +264,16 @@ namespace KellermanSoftware.CompareNetObjectsTests
             Assert.IsFalse(_compare.Compare(brush1, brush2).AreEqual);
         }
 
+        [Test]
+        public void DecimalCollectionWhenOrderIgnored()
+        {
+            var compare = new CompareLogic(new ComparisonConfig
+            {
+                IgnoreCollectionOrder = true
+            });
+            Assert.IsTrue(compare.Compare(new decimal[] { 10, 1 }, new [] { 10.0m, 1.0m }).AreEqual);
+        }
+
         #endregion
     }
 }

--- a/Compare-NET-Objects/IgnoreOrderTypes/IgnoreOrderLogic.cs
+++ b/Compare-NET-Objects/IgnoreOrderTypes/IgnoreOrderLogic.cs
@@ -249,12 +249,24 @@ namespace KellermanSoftware.CompareNetObjects.IgnoreOrderTypes
             }
 
             if (sb.Length == 0)
-                sb.Append(currentObject);
+                sb.Append(RespectNumberToString(currentObject));
 
             return sb.ToString().TrimEnd(',');
         }
 
-
+        private static string RespectNumberToString(object o)
+        {
+            switch (Type.GetTypeCode(o.GetType()))
+            {
+                case TypeCode.Decimal:
+                    return ((decimal) o).ToString("G29");
+                case TypeCode.Double:
+                case TypeCode.Single:
+                    return ((double)o).ToString("G");
+                default:
+                    return o.ToString();
+            }
+        }
 
         private List<string> GetMatchingSpec(ComparisonResult result,Type type)
         {


### PR DESCRIPTION
10m.ToString() != 10.0m.ToString()

have to use G29 specifier (29 is precision)