### PR TITLE
Added base class check to IgnoreOrderLogic so CollectionMatchingSpec …

### DIFF
--- a/Compare-NET-Objects-Tests/Compare-NET-Objects-Tests.csproj
+++ b/Compare-NET-Objects-Tests/Compare-NET-Objects-Tests.csproj
@@ -109,6 +109,7 @@
     <Compile Include="TestClasses\BigElchie.cs" />
     <Compile Include="TestClasses\ClassWithGuid.cs" />
     <Compile Include="TestClasses\ClassWithTuple.cs" />
+    <Compile Include="TestClasses\DeriveFromOfficer.cs" />
     <Compile Include="TestClasses\Element.cs" />
     <Compile Include="TestClasses\Entity.cs" />
     <Compile Include="TestClasses\EntityWithEquality.cs" />
@@ -203,7 +204,9 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Compare-NET-Objects-Tests/IgnoreOrderTests.cs
+++ b/Compare-NET-Objects-Tests/IgnoreOrderTests.cs
@@ -1094,6 +1094,32 @@ namespace KellermanSoftware.CompareNetObjectsTests
             Assert.AreEqual(result.Differences[2].PropertyName, ".Children[Id:11].Children[Id:101].Description");
         }
 
+        [Test]
+        public void CompareListsIgnoreOrderMatchingSpecValueInBaseClass()
+        {
+            List<DeriveFromOfficer> list1 = new List<DeriveFromOfficer>();
+            list1.Add(new DeriveFromOfficer() { ID = 1, Name = "Logan 5" });
+            list1.Add(new DeriveFromOfficer() { ID = 2, Name = "Francis 7" });
+
+            List<DeriveFromOfficer> list2 = new List<DeriveFromOfficer>();
+            list2.Add(new DeriveFromOfficer() { ID = 2, Name = "Francis 7" });
+            list2.Add(new DeriveFromOfficer() { ID = 1, Name = "Logan 4" });
+
+            ComparisonConfig config = new ComparisonConfig();
+            Dictionary<Type, IEnumerable<string>> collectionSpec = new Dictionary<Type, IEnumerable<string>>();
+            collectionSpec.Add(typeof(Officer), new string[] { "ID" });
+
+            config.IgnoreCollectionOrder = true;
+            config.CollectionMatchingSpec = collectionSpec;
+
+            CompareLogic compareLogic = new CompareLogic(config);
+            var result = compareLogic.Compare(list1, list2);
+            Assert.IsFalse(result.AreEqual);
+            Assert.AreNotEqual(result.Differences.First().Object2, null);
+            Assert.AreEqual(result.Differences.First().Object1.Target, "Logan 5");
+            Assert.AreEqual(result.Differences.First().Object2.Target, "Logan 4");
+        }
+
         #endregion
     }
 }

--- a/Compare-NET-Objects/IgnoreOrderTypes/IgnoreOrderLogic.cs
+++ b/Compare-NET-Objects/IgnoreOrderTypes/IgnoreOrderLogic.cs
@@ -287,16 +287,10 @@ namespace KellermanSoftware.CompareNetObjects.IgnoreOrderTypes
         private List<string> GetMatchingSpec(ComparisonResult result,Type type)
         {
             //The user defined a key for the order
-            if (result.Config.CollectionMatchingSpec.Keys.Contains(type))
+            var matchingBasePresent = result.Config.CollectionMatchingSpec.Keys.FirstOrDefault(k => k.IsAssignableFrom(type));
+            if (matchingBasePresent != null)
             {
-                return result.Config.CollectionMatchingSpec.First(p => p.Key == type).Value.ToList();
-            }
-
-            Type[] typeInterfaces = type.GetInterfaces();
-            bool matchingInterfacePresent = result.Config.CollectionMatchingSpec.Keys.Any(k => typeInterfaces.Any(t => t == k));
-            if (matchingInterfacePresent)
-            {
-                return result.Config.CollectionMatchingSpec.First(p => typeInterfaces.Contains(p.Key)).Value.ToList();
+                return result.Config.CollectionMatchingSpec.First(p => p.Key == matchingBasePresent).Value.ToList();
             }
 
             //Make a key out of primative types, date, decimal, string, guid, and enum of the class


### PR DESCRIPTION
…can also be used on base class

This is the pull request that I spoke of in #61. I even reduced code because the change I introduced checks also if a class implements an interface.

With kind regards,

Cees