### PR TITLE
Fix TypeHelper.IsByteArray to correctly determine if the given type i…

### DIFF
--- a/Compare-NET-Objects-Tests/CompareIListTests.cs
+++ b/Compare-NET-Objects-Tests/CompareIListTests.cs
@@ -489,6 +489,20 @@ namespace KellermanSoftware.CompareNetObjectsTests
         }
 
         [Test]
+        public void CompareListsOfStringBytePairs()
+        {
+            var list1 = new List<KeyValuePair<string, byte>> { new KeyValuePair<string, byte>("hello", 1) };
+            var list2 = new List<KeyValuePair<string, byte>> { new KeyValuePair<string, byte>("world", 2) };
+
+            ComparisonConfig config = new ComparisonConfig();
+            config.IgnoreObjectTypes = true;
+
+            CompareLogic compareLogic = new CompareLogic(config);
+            var result = compareLogic.Compare(list1, list2);
+            Assert.IsFalse(result.AreEqual);
+        }
+
+        [Test]
         public void ListOfNullObjects()
         {
             Person p1 = null;

--- a/Compare-NET-Objects/TypeHelper.cs
+++ b/Compare-NET-Objects/TypeHelper.cs
@@ -35,22 +35,12 @@ namespace KellermanSoftware.CompareNetObjects
         /// <summary>
         /// Returns true if it is a byte array
         /// </summary>
-        /// <param name="type"></param>
-        /// <returns></returns>
         public static bool IsByteArray(Type type)
         {
-            if (!IsIList(type))
-                return false;
-
-#if !DNCORE
-            var fullName = type.UnderlyingSystemType.FullName;
-#else
-            var fullName = type.FullName;
-#endif
-            if (fullName.Contains("System.Byte"))
-                return true;
-
-            return false;
+            return IsIList(type) && (
+                typeof(IEnumerable<byte>).IsAssignableFrom(type) ||
+                typeof(IEnumerable<byte?>).IsAssignableFrom(type)
+                );
         }
 
         /// <summary>


### PR DESCRIPTION
The original implementation is incorrect. It would determine that any collection which name contains System.Byte is a collection of bytes. For example `List<KeyValuePair<string, byte>>` is determined as a collection of bytes.

The net result - incorrect comparison result - see a new unit test, which proves the point.

The pull request contains the fix and the unit test.