### PR TITLE
Add CollectionComparer to compare collections of different types.

### DIFF
--- a/Compare-NET-Objects-Portable/Compare-NET-Objects-Portable.csproj
+++ b/Compare-NET-Objects-Portable/Compare-NET-Objects-Portable.csproj
@@ -113,6 +113,9 @@
     <Compile Include="..\Compare-NET-Objects\TypeComparers\ClassComparer.cs">
       <Link>TypeComparers\ClassComparer.cs</Link>
     </Compile>
+    <Compile Include="..\Compare-NET-Objects\TypeComparers\CollectionComparer.cs">
+      <Link>TypeComparers\CollectionComparer.cs</Link>
+    </Compile>
     <Compile Include="..\Compare-NET-Objects\TypeComparers\DateComparer.cs">
       <Link>TypeComparers\DateComparer.cs</Link>
     </Compile>

--- a/Compare-NET-Objects-Tests/Compare-NET-Objects-Tests.csproj
+++ b/Compare-NET-Objects-Tests/Compare-NET-Objects-Tests.csproj
@@ -86,6 +86,7 @@
     <Compile Include="CompareEnumeratorTests.cs" />
     <Compile Include="CompareEnumTests.cs" />
     <Compile Include="CompareExtensionsTests.cs" />
+    <Compile Include="CompareCollectionsTests.cs" />
     <Compile Include="CompareHashsetTests.cs" />
     <Compile Include="CompareIListTests.cs" />
     <Compile Include="CompareIndexerTests.cs" />

--- a/Compare-NET-Objects-Tests/CompareCollectionsTests.cs
+++ b/Compare-NET-Objects-Tests/CompareCollectionsTests.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using KellermanSoftware.CompareNetObjects;
+using NUnit.Framework;
+
+namespace KellermanSoftware.CompareNetObjectsTests
+{
+    [TestFixture]
+    public class CompareCollectionsTests
+    {
+        [Test]
+        public void CollectionsSame()
+        {
+            var coll1 = new List<KeyValuePair<string, byte[]>>
+            {
+                new KeyValuePair<string, byte[]>("Hello", new byte[] { 1, 2, 3 })
+            };
+            var coll2 = new Dictionary<string, byte[]>
+            {
+                {"Hello", new byte[] { 1, 2, 3 } }
+            };
+            var compareLogic = new CompareLogic
+            {
+                Config = new ComparisonConfig
+                {
+                    IgnoreObjectTypes = true,
+                    IgnoreCollectionOrder = true
+                }
+            };
+
+            Assert.IsTrue(compareLogic.Compare(coll1, coll2).AreEqual);
+        }
+    }
+}

--- a/Compare-NET-Objects/Compare-NET-Objects.csproj
+++ b/Compare-NET-Objects/Compare-NET-Objects.csproj
@@ -113,6 +113,7 @@
     <Compile Include="ExcludeLogic.cs" />
     <Compile Include="TypeComparers\FieldComparer.cs" />
     <Compile Include="TypeComparers\FontComparer.cs" />
+    <Compile Include="TypeComparers\CollectionComparer.cs" />
     <Compile Include="TypeComparers\HashSetComparer.cs" />
     <Compile Include="TypeComparers\ListComparer.cs" />
     <Compile Include="TypeComparers\IndexerComparer.cs" />

--- a/Compare-NET-Objects/RootComparerFactory.cs
+++ b/Compare-NET-Objects/RootComparerFactory.cs
@@ -49,6 +49,7 @@ namespace KellermanSoftware.CompareNetObjects
             _rootComparer.TypeComparers.Add(new DictionaryComparer(_rootComparer));
             _rootComparer.TypeComparers.Add(new ListComparer(_rootComparer));
             _rootComparer.TypeComparers.Add(new HashSetComparer(_rootComparer));
+            _rootComparer.TypeComparers.Add(new CollectionComparer(_rootComparer));
             _rootComparer.TypeComparers.Add(new EnumComparer(_rootComparer));
             _rootComparer.TypeComparers.Add(new PointerComparer(_rootComparer));
             _rootComparer.TypeComparers.Add(new UriComparer(_rootComparer));

--- a/Compare-NET-Objects/TypeComparers/CollectionComparer.cs
+++ b/Compare-NET-Objects/TypeComparers/CollectionComparer.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections;
+using System.Globalization;
+using KellermanSoftware.CompareNetObjects.IgnoreOrderTypes;
+
+namespace KellermanSoftware.CompareNetObjects.TypeComparers
+{
+    /// <summary>
+    /// Logic to compare two collections of different types.
+    /// </summary>
+    public class CollectionComparer : BaseTypeComparer
+    {
+        /// <summary>
+        /// The main constructor.
+        /// </summary>
+        public CollectionComparer(RootComparer rootComparer) : base(rootComparer)
+        {
+        }
+
+        /// <summary>
+        /// Returns true if both objects are collections.
+        /// </summary>
+        /// <param name="type1">The type of the first object</param>
+        /// <param name="type2">The type of the second object</param>
+        /// <returns></returns>
+        public override bool IsTypeMatch(Type type1, Type type2)
+        {
+            return typeof(ICollection).IsAssignableFrom(type1) && typeof(ICollection).IsAssignableFrom(type2);
+        }
+
+        /// <summary>
+        /// Compare two collections.
+        /// </summary>
+        public override void CompareType(CompareParms parms)
+        {
+            try
+            {
+                parms.Result.AddParent(parms.Object1.GetHashCode());
+                parms.Result.AddParent(parms.Object2.GetHashCode());
+
+                parms.Object1Type = parms.Object1.GetType();
+                parms.Object2Type = parms.Object2.GetType();
+
+                bool countsDifferent = CollectionsDifferentCount(parms);
+
+                if (parms.Result.ExceededDifferences)
+                    return;
+
+                if (parms.Config.IgnoreCollectionOrder)
+                {
+                    IgnoreOrderLogic logic = new IgnoreOrderLogic(RootComparer);
+                    logic.CompareEnumeratorIgnoreOrder(parms, countsDifferent);
+                }
+                else
+                {
+                    CompareItems(parms);
+                }
+            }
+            finally
+            {
+                parms.Result.RemoveParent(parms.Object1.GetHashCode());
+                parms.Result.RemoveParent(parms.Object2.GetHashCode());
+            }
+        }
+
+        private void CompareItems(CompareParms parms)
+        {
+            int count = 0;
+
+            IEnumerator enumerator1 = ((ICollection)parms.Object1).GetEnumerator();
+            IEnumerator enumerator2 = ((ICollection)parms.Object2).GetEnumerator();
+
+            while (enumerator1.MoveNext() && enumerator2.MoveNext())
+            {
+                string currentBreadCrumb = AddBreadCrumb(parms.Config, parms.BreadCrumb, string.Empty, string.Empty, count);
+
+                CompareParms childParms = new CompareParms
+                {
+                    Result = parms.Result,
+                    Config = parms.Config,
+                    ParentObject1 = parms.Object1,
+                    ParentObject2 = parms.Object2,
+                    Object1 = enumerator1.Current,
+                    Object2 = enumerator2.Current,
+                    BreadCrumb = currentBreadCrumb
+                };
+
+                RootComparer.Compare(childParms);
+
+                if (parms.Result.ExceededDifferences)
+                    return;
+
+                count++;
+            }
+        }
+
+        private bool CollectionsDifferentCount(CompareParms parms)
+        {
+            //Get count by reflection since we can't cast it to HashSet<>
+            int count1 = ((ICollection)parms.Object1).Count;
+            int count2 = ((ICollection)parms.Object2).Count;
+
+            //Objects must be the same length
+            if (count1 != count2)
+            {
+                Difference difference = new Difference
+                {
+                    ParentObject1 = parms.ParentObject1,
+                    ParentObject2 = parms.ParentObject2,
+                    PropertyName = parms.BreadCrumb,
+                    Object1Value = count1.ToString(CultureInfo.InvariantCulture),
+                    Object2Value = count2.ToString(CultureInfo.InvariantCulture),
+                    ChildPropertyName = "Count",
+                    Object1 = parms.Object1,
+                    Object2 = parms.Object2
+                };
+
+                AddDifference(parms.Result, difference);
+
+                return true;
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
When `IgnoreObjectTypes `is set, one expects `List<KeyValuePair<K,V>>` to be comparable to `Dictionary<K, V>`, yet the current implementation does not do it.

This pull requests adds CollectionComparer and the respective unit test to resolve this situation.

The .NET Core code is not updated - I do not have .NET Core.