### PR TITLE
Handle classes with write-only properties

### DIFF
--- a/Compare-NET-Objects-Tests/Compare-NET-Objects-Tests.csproj
+++ b/Compare-NET-Objects-Tests/Compare-NET-Objects-Tests.csproj
@@ -196,6 +196,7 @@
     <Compile Include="TestClasses\Size.cs" />
     <Compile Include="TestClasses\SpecialFields.cs" />
     <Compile Include="TestClasses\Table.cs" />
+    <Compile Include="TestClasses\WriteOnlyPropertyClass.cs" />
     <Compile Include="ThreadSafeTests.cs" />
     <Compile Include="WildcardTests.cs" />
   </ItemGroup>

--- a/Compare-NET-Objects-Tests/CompareClassTests.cs
+++ b/Compare-NET-Objects-Tests/CompareClassTests.cs
@@ -237,5 +237,26 @@ namespace KellermanSoftware.CompareNetObjectsTests
         }
         #endregion
 
+        #region Set-only Property Tests
+
+        [Test]
+        public void WriteOnlyPropertyTests()
+        {
+            WriteOnlyPropertyClass c1 = new WriteOnlyPropertyClass
+            {
+                Name = "Jim",
+                WriteOnly = 1
+            };
+
+            WriteOnlyPropertyClass c2 = new WriteOnlyPropertyClass
+            {
+                Name = "Jim",
+                WriteOnly = 2
+            };
+
+            Assert.IsTrue(_compare.Compare(c1, c2).AreEqual);            
+        }
+
+        #endregion
     }
 }

--- a/Compare-NET-Objects-Tests/TestClasses/WriteOnlyPropertyClass.cs
+++ b/Compare-NET-Objects-Tests/TestClasses/WriteOnlyPropertyClass.cs
@@ -1,0 +1,14 @@
+﻿namespace KellermanSoftware.CompareNetObjectsTests.TestClasses
+{
+    internal class WriteOnlyPropertyClass
+    {
+        private int _value;
+
+        public string Name { get; set; }
+
+        public int WriteOnly
+        {
+            set { _value = value; }
+        }
+    }
+}

--- a/Compare-NET-Objects/TypeComparers/PropertyComparer.cs
+++ b/Compare-NET-Objects/TypeComparers/PropertyComparer.cs
@@ -154,7 +154,7 @@ namespace KellermanSoftware.CompareNetObjects.TypeComparers
                 propertyEntity.Indexers.AddRange(property.GetIndexParameters());
                 propertyEntity.DeclaringType = objectType;
 
-                if (propertyEntity.Indexers.Count == 0)
+                if (propertyEntity.CanRead && (propertyEntity.Indexers.Count == 0))
                 {
                     try
                     {


### PR DESCRIPTION
I came across a bug where `HandleNormalProperties` threw an exception when passed a class with write-only properties (ones with a setter but no getter).  I have made a fix and added a test, but please let me know if there is a better way to achieve this