### PR TITLE
For comparing unordered collections - respect settings for casesensit…

### DIFF
--- a/Compare-NET-Objects-Tests/IgnoreOrderTests.cs
+++ b/Compare-NET-Objects-Tests/IgnoreOrderTests.cs
@@ -1160,6 +1160,123 @@ namespace KellermanSoftware.CompareNetObjectsTests
             var result = _compare.Compare(list1, list2);
             Assert.IsTrue(result.AreEqual, result.DifferencesString);
         }
+
+        [Test]
+        public void CompareListsIgnoreOrderTypeAndNull()
+        {
+            List<Person> list1 = new List<Person>();
+            list1.Add(new Person() { ID = 1, Name = "Logan 5" });
+            list1.Add(new Person() { ID = 2, Name = "Francis 7" });
+            list1.Add(new Person() { ID = 3, Name = null });
+
+            List<Officer> list2 = new List<Officer>();
+            list2.Add(new Officer() { ID = 2, Name = "Francis 7" });
+            list2.Add(new Officer() { ID = 1, Name = "Logan 5" });
+            list2.Add(new Officer() { ID = 3, Name = string.Empty });
+
+            ComparisonConfig config = new ComparisonConfig();
+            Dictionary<Type, IEnumerable<string>> collectionSpec = new Dictionary<Type, IEnumerable<string>>();
+            collectionSpec.Add(typeof(Person), new string[] { "ID", "Name" });
+            collectionSpec.Add(typeof(Officer), new string[] { "ID", "Name" });
+
+            config.IgnoreObjectTypes = true;
+            config.IgnoreCollectionOrder = true;
+            config.TreatStringEmptyAndNullTheSame = true;
+            config.CollectionMatchingSpec = collectionSpec;
+
+            CompareLogic compareLogic = new CompareLogic(config);
+            var result = compareLogic.Compare(list1, list2);
+            Assert.IsTrue(result.AreEqual);
+        }
+
+        [Test]
+        public void CompareListsIgnoreOrderAndNull()
+        {
+            List<Person> list1 = new List<Person>();
+            list1.Add(new Person() { ID = 1, Name = "Logan 5" });
+            list1.Add(new Person() { ID = 2, Name = "Francis 7" });
+            list1.Add(new Person() { ID = 3, Name = null });
+
+            List<Person> list2 = new List<Person>();
+            list2.Add(new Person() { ID = 2, Name = "Francis 7" });
+            list2.Add(new Person() { ID = 1, Name = "Logan 5" });
+            list2.Add(new Person() { ID = 3, Name = string.Empty });
+
+            ComparisonConfig config = new ComparisonConfig();
+
+            config.IgnoreCollectionOrder = true;
+            config.TreatStringEmptyAndNullTheSame = true;
+
+            CompareLogic compareLogic = new CompareLogic(config);
+            var result = compareLogic.Compare(list1, list2);
+            Assert.IsTrue(result.AreEqual);
+        }
+
+        [Test]
+        public void CompareListsInOrderAndIgnoreNull()
+        {
+            List<Person> list1 = new List<Person>();
+            list1.Add(new Person() { ID = 1, Name = "Logan 5" });
+            list1.Add(new Person() { ID = 2, Name = "Francis 7" });
+            list1.Add(new Person() { ID = 3, Name = null });
+
+            List<Person> list2 = new List<Person>();
+            list2.Add(new Person() { ID = 1, Name = "Logan 5" });
+            list2.Add(new Person() { ID = 2, Name = "Francis 7" });
+            list2.Add(new Person() { ID = 3, Name = string.Empty });
+
+            ComparisonConfig config = new ComparisonConfig();
+
+            config.IgnoreCollectionOrder = true;
+            config.TreatStringEmptyAndNullTheSame = true;
+
+            CompareLogic compareLogic = new CompareLogic(config);
+            var result = compareLogic.Compare(list1, list2);
+            Assert.IsTrue(result.AreEqual);
+        }
+
+        [Test]
+        public void CompareListsIgnoreOrderAndCase()
+        {
+            List<Person> list1 = new List<Person>();
+            list1.Add(new Person() { ID = 1, Name = "Logan 5" });
+            list1.Add(new Person() { ID = 2, Name = "Francis 7" });
+
+            List<Person> list2 = new List<Person>();
+            list2.Add(new Person() { ID = 2, Name = "francis 7" });
+            list2.Add(new Person() { ID = 1, Name = "logan 5" });
+
+            ComparisonConfig config = new ComparisonConfig();
+
+            config.IgnoreCollectionOrder = true;
+            config.CaseSensitive = false;
+
+            CompareLogic compareLogic = new CompareLogic(config);
+            var result = compareLogic.Compare(list1, list2);
+            Assert.IsTrue(result.AreEqual);
+        }
+
+        [Test]
+        public void CompareListsInOrderAndIgnorCase()
+        {
+            List<Person> list1 = new List<Person>();
+            list1.Add(new Person() { ID = 1, Name = "Logan 5" });
+            list1.Add(new Person() { ID = 2, Name = "Francis 7" });
+
+            List<Person> list2 = new List<Person>();
+            list2.Add(new Person() { ID = 1, Name = "logan 5" });
+            list2.Add(new Person() { ID = 2, Name = "francis 7" });
+            
+
+            ComparisonConfig config = new ComparisonConfig();
+
+            config.IgnoreCollectionOrder = true;
+            config.CaseSensitive = false;
+
+            CompareLogic compareLogic = new CompareLogic(config);
+            var result = compareLogic.Compare(list1, list2);
+            Assert.IsTrue(result.AreEqual);
+        }
         #endregion
     }
 }

--- a/Compare-NET-Objects/IgnoreOrderTypes/IgnoreOrderLogic.cs
+++ b/Compare-NET-Objects/IgnoreOrderTypes/IgnoreOrderLogic.cs
@@ -265,6 +265,15 @@ namespace KellermanSoftware.CompareNetObjects.IgnoreOrderTypes
 
                 var propertyValue = info.GetValue(currentObject, null);
 
+                if (result.Config.TreatStringEmptyAndNullTheSame && info.PropertyType == typeof(string) && propertyValue == null)
+                {
+                    propertyValue = string.Empty;
+                }
+                else if (result.Config.CaseSensitive == false && info.PropertyType == typeof(string))
+                {
+                    propertyValue = ((string)propertyValue).ToLowerInvariant();
+                }
+
                 if (propertyValue == null)
                 {
                     sb.AppendFormat("{0}:(null),",item);


### PR DESCRIPTION
…ivity and treat null and string.empty as same

Hi - had some trouble with Compare.Net when comparing arrays of objects where some properties on the objects was string.empty on one end and null on the other.... Found similar problems with casesensitivity

Basically config.IgnoreCollectionOrder = true did not work well with config.TreatStringEmptyAndNullTheSame = true or config.CaseSensitive = false.

Se included tests - that will fail without my fix...

Would be nice if this one could be accepted and a new nuget package published- as it would fix mentioned problems in another project im working on..

Please review my changes.