### PR TITLE
Complete private field and property support for .NET Standard (where …

### DIFF
--- a/Compare-NET-Objects-Tests/BugTests.cs
+++ b/Compare-NET-Objects-Tests/BugTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using KellermanSoftware.CompareNetObjects;
 using KellermanSoftware.CompareNetObjectsTests.Attributes;
@@ -9,7 +8,6 @@ using System.Drawing;
 using System.Linq;
 using System.Reflection;
 using KellermanSoftware.CompareNetObjects.Reports;
-using KellermanSoftware.CompareNetObjectsTests.TestClasses.Bal;
 using Point = System.Drawing.Point;
 
 #if !NETSTANDARD
@@ -60,6 +58,40 @@ namespace KellermanSoftware.CompareNetObjectsTests
 
             //Assert
             Assert.IsTrue(props.Length > 0);
+        }
+
+        /// <summary>
+        /// https://github.com/GregFinzer/Compare-Net-Objects/issues/77
+        /// </summary>
+        [Test]
+        public void ComparisonsOfTypesWithPrivateFieldsAreAccurate()
+        {
+            var compareLogic = new CompareLogic(new ComparisonConfig { ComparePrivateFields = true });
+            var result = compareLogic.Compare(new SomethingWithPrivateField(123), new SomethingWithPrivateField(456));
+            Assert.IsFalse(result.AreEqual);
+        }
+
+        private class SomethingWithPrivateField
+        {
+            private readonly int _key;
+            public SomethingWithPrivateField(int key) { _key = key; }
+        }
+
+        /// <summary>
+        /// https://github.com/GregFinzer/Compare-Net-Objects/issues/77
+        /// </summary>
+        [Test]
+        public void ComparisonsOfTypesWithPrivatePropertiesAreAccurate()
+        {
+            var compareLogic = new CompareLogic(new ComparisonConfig { ComparePrivateProperties = true });
+            var result = compareLogic.Compare(new SomethingWithPrivateProperty(123), new SomethingWithPrivateProperty(456));
+            Assert.IsFalse(result.AreEqual);
+        }
+
+        private class SomethingWithPrivateProperty
+        {
+            public SomethingWithPrivateProperty(int key) { Key = key; }
+            private int Key { get; }
         }
 
         /// <summary>

--- a/Compare-NET-Objects/Cache.cs
+++ b/Compare-NET-Objects/Cache.cs
@@ -65,7 +65,7 @@ namespace KellermanSoftware.CompareNetObjects
 
                 FieldInfo[] currentFields;
 
-#if !NETSTANDARD
+#if !NETSTANDARD1_3
                 if (config.ComparePrivateFields && !config.CompareStaticFields)
                 {
                     List<FieldInfo> list = new List<FieldInfo>();
@@ -132,6 +132,12 @@ namespace KellermanSoftware.CompareNetObjects
 
                 PropertyInfo[] currentProperties;
 
+#if NETSTANDARD1_3
+                if (!config.CompareStaticProperties)
+                    currentProperties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+                else
+                    currentProperties = type.GetProperties(); //Default is public instance and static
+#else
                 if (config.ComparePrivateProperties && !config.CompareStaticProperties)
                     currentProperties =
                         type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
@@ -142,6 +148,7 @@ namespace KellermanSoftware.CompareNetObjects
                 else if (!config.CompareStaticProperties)
                     currentProperties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
                 else
+#endif
                     currentProperties = type.GetProperties(); //Default is public instance and static
 
                 if (config.Caching)

--- a/Compare-NET-Objects/ComparisonConfig.cs
+++ b/Compare-NET-Objects/ComparisonConfig.cs
@@ -173,6 +173,7 @@ namespace KellermanSoftware.CompareNetObjects
 #endif
         public List<string> MembersToInclude { get; set; }
 
+#if !NETSTANDARD1_3
         /// <summary>
         /// If true, private properties and fields will be compared. The default is false.  Silverlight and WinRT restricts access to private variables.
         /// </summary>
@@ -180,7 +181,9 @@ namespace KellermanSoftware.CompareNetObjects
         [DataMember]
 #endif
         public bool ComparePrivateProperties { get; set; }
+#endif
 
+#if !NETSTANDARD1_3
         /// <summary>
         /// If true, private fields will be compared. The default is false.  Silverlight and WinRT restricts access to private variables.
         /// </summary>
@@ -188,6 +191,7 @@ namespace KellermanSoftware.CompareNetObjects
         [DataMember]
 #endif
         public bool ComparePrivateFields { get; set; }
+#endif
 
         /// <summary>
         /// If true, static properties will be compared.  The default is true.


### PR DESCRIPTION
…it's supported, which isn't in 1.3)

The ComparisonConfig options will not in the .NET Standard 1.3 build but they will be for .NET Framework and .NET Standard 2.0. The "BaseType" reflection property is not available in 1.3, reflection was quite limited back then.