### PR TITLE
Minor optimizations for wildcards and baselist properties

### DIFF
--- a/Compare-NET-Objects/ComparisonConfig.cs
+++ b/Compare-NET-Objects/ComparisonConfig.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using KellermanSoftware.CompareNetObjects.TypeComparers;
+using System.Linq;
 #if !NETSTANDARD
 using System.Runtime.Serialization;
 #endif
@@ -396,6 +397,24 @@ namespace KellermanSoftware.CompareNetObjects
 
         #region Methods
 
+        /// <summary>
+        /// Backing member that supports <see cref="HasWildcardMembersToExclude"/>
+        /// </summary>
+        private bool? _hasWildcardInMembersToIgnore;
+
+        /// <summary>
+        /// Computed value of whether or not exclusion list has wildcards.
+        /// </summary>
+        public bool HasWildcardMembersToExclude()
+        {
+            if (_hasWildcardInMembersToIgnore.HasValue)
+            {
+                return _hasWildcardInMembersToIgnore.Value;
+            }
+
+            _hasWildcardInMembersToIgnore = MembersToIgnore.Any(x => x.IndexOf("*") > -1);
+            return _hasWildcardInMembersToIgnore.Value;
+        }
 
         /// <summary>
         /// Reset the configuration to the default values
@@ -406,6 +425,8 @@ namespace KellermanSoftware.CompareNetObjects
             _differenceCallback = d => { };
 
             MembersToIgnore = new List<string>();
+            _hasWildcardInMembersToIgnore = null;
+
             MembersToInclude = new List<string>();
             ClassTypesToIgnore = new List<Type>();
             ClassTypesToInclude = new List<Type>();

--- a/Compare-NET-Objects/ExcludeLogic.cs
+++ b/Compare-NET-Objects/ExcludeLogic.cs
@@ -34,7 +34,7 @@ namespace KellermanSoftware.CompareNetObjects
                     return true;
 
                 //Wildcard member
-                if (ExcludedByWildcard(config, info))
+                if (config.HasWildcardMembersToExclude() && ExcludedByWildcard(config, info))
                     return true;
             }
 

--- a/Compare-NET-Objects/TypeComparers/PropertyComparer.cs
+++ b/Compare-NET-Objects/TypeComparers/PropertyComparer.cs
@@ -12,6 +12,7 @@ namespace KellermanSoftware.CompareNetObjects.TypeComparers
     {
         private readonly RootComparer _rootComparer;
         private readonly IndexerComparer _indexerComparer;
+        private static readonly string[] _baseList = { "Count", "Capacity", "Item" };
 
         /// <summary>
         /// Constructor that takes a root comparer
@@ -28,14 +29,12 @@ namespace KellermanSoftware.CompareNetObjects.TypeComparers
         /// </summary>
         public void PerformCompareProperties(CompareParms parms, bool ignoreBaseList= false)
         {
-            string[] baseList = {"Count", "Capacity", "Item"};
-
             List<PropertyEntity> object1Properties = GetCurrentProperties(parms, parms.Object1, parms.Object1Type);
             List<PropertyEntity> object2Properties = GetCurrentProperties(parms, parms.Object2, parms.Object2Type);
 
             foreach (PropertyEntity propertyEntity in object1Properties)
             {
-                if (ignoreBaseList && baseList.Contains(propertyEntity.Name))
+                if (ignoreBaseList && _baseList.Contains(propertyEntity.Name))
                     continue;
                     
                 CompareProperty(parms, propertyEntity, object2Properties);


### PR DESCRIPTION
Hello, I was working through an issue (which I resolved by flipping a few config options) and noticed a few small things that I'd see if you'd want contributions for.

- Currently, in `ExcludeLogic` `ExcludedByWildcard` will be invoked for any member that has yet to meet other criteria.  I've added a method on `ComparisonConfig` which encapsulates the state of `MembersToIgnore` and whether or not a wildcard ignore expression is in there.  Based on tests, there doesn't seem to be an expectation that `MembersToIgnore` should change once the config is "set".  I'd defer to you if this calculation should be hidden behind a separate configuration flag to opt-in to caching this value.

- `PropertyComparer` always allows an array for the known `baseList` property names.  I've moved that to a `private static readonly`