### PR TITLE
Fix IndexerComparer when comparing different list types

### DIFF
--- a/Compare-NET-Objects-Tests/CompareIListTests.cs
+++ b/Compare-NET-Objects-Tests/CompareIListTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using KellermanSoftware.CompareNetObjects;
 using KellermanSoftware.CompareNetObjectsTests.TestClasses;
@@ -523,6 +524,98 @@ namespace KellermanSoftware.CompareNetObjectsTests
 
             if (!result.AreEqual)
                 throw new Exception(result.DifferencesString);
+        }
+
+        [Test]
+        public void CompareListsTwoDifferentListTypes()
+        {
+            List<Person> list1 = new List<Person>();
+            list1.Add(new Person(){Name="Logan 5"});
+            list1.Add(new Person(){Name="Francis 7"});
+
+            NewList<Person> list2 = new NewList<Person>(list1);
+
+            ComparisonConfig config = new ComparisonConfig();
+            config.IgnoreObjectTypes = true;
+
+            CompareLogic compareLogic = new CompareLogic(config);
+            var result = compareLogic.Compare(list1, list2);
+            Assert.IsTrue(result.AreEqual);
+
+            list2.Add(new Person(){Name="Roger 4"});
+
+            result = compareLogic.Compare(list1, list2);
+            Assert.IsFalse(result.AreEqual);
+        }
+
+        private class NewList<T> : IList<T>
+        {
+            private readonly IList<T> _wrappedList;
+
+            public NewList(IEnumerable<T> list)
+            {
+                _wrappedList = new List<T>(list);;
+            }
+
+            public IEnumerator<T> GetEnumerator()
+            {
+                return _wrappedList.GetEnumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return _wrappedList.GetEnumerator();
+            }
+
+            public void Add(T item)
+            {
+                _wrappedList.Add(item);
+            }
+
+            public void Clear()
+            {
+                _wrappedList.Clear();
+            }
+
+            public bool Contains(T item)
+            {
+                return _wrappedList.Contains(item);
+            }
+
+            public void CopyTo(T[] array, int arrayIndex)
+            {
+                _wrappedList.CopyTo(array, arrayIndex);
+            }
+
+            public bool Remove(T item)
+            {
+                return _wrappedList.Remove(item);
+            }
+
+            public int Count => _wrappedList.Count;
+
+            public bool IsReadOnly => _wrappedList.IsReadOnly;
+
+            public int IndexOf(T item)
+            {
+                return _wrappedList.IndexOf(item);
+            }
+
+            public void Insert(int index, T item)
+            {
+                _wrappedList.Insert(index, item);
+            }
+
+            public void RemoveAt(int index)
+            {
+                _wrappedList.RemoveAt(index);
+            }
+
+            public T this[int index]
+            {
+                get => _wrappedList[index];
+                set => _wrappedList[index] = value;
+            }
         }
 
         #endregion

--- a/Compare-NET-Objects/TypeComparers/IndexerComparer.cs
+++ b/Compare-NET-Objects/TypeComparers/IndexerComparer.cs
@@ -24,22 +24,24 @@ namespace KellermanSoftware.CompareNetObjects.TypeComparers
         /// <summary>
         /// Compare an integer indexer
         /// </summary>
-        public void CompareIndexer(CompareParms parms, PropertyEntity info)
+        public void CompareIndexer(CompareParms parms, PropertyEntity info, PropertyEntity secondObjectInfo)
         {
             if (info == null)
                 throw new ArgumentNullException("info");
 #if !NETSTANDARD
             var type = info.ReflectedType;
+            var type2 = secondObjectInfo.ReflectedType;
 #else
             var type = info.DeclaringType;
+            var type2 = secondObjectInfo.DeclaringType;
 #endif
-            if (type == null)
+            if (type == null || type2 == null)
                 throw new ArgumentNullException("info");
 
             int indexerCount1 = (int)type.GetProperty("Count").GetGetMethod().Invoke(parms.Object1, new object[] { });
-            int indexerCount2 = (int)type.GetProperty("Count").GetGetMethod().Invoke(parms.Object2, new object[] { });
+            int indexerCount2 = (int)type2.GetProperty("Count").GetGetMethod().Invoke(parms.Object2, new object[] { });
 
-            bool differentCounts = IndexersHaveDifferentLength(parms, info);
+            bool differentCounts = IndexersHaveDifferentLength(parms, info, secondObjectInfo);
 
             if (parms.Result.ExceededDifferences)
                 return;
@@ -47,7 +49,7 @@ namespace KellermanSoftware.CompareNetObjects.TypeComparers
             if (parms.Config.IgnoreCollectionOrder)
             {
                 var enumerable1 = new IndexerCollectionLooper(parms.Object1, info.PropertyInfo, indexerCount1);
-                var enumerable2 = new IndexerCollectionLooper(parms.Object2, info.PropertyInfo, indexerCount2);
+                var enumerable2 = new IndexerCollectionLooper(parms.Object2, secondObjectInfo.PropertyInfo, indexerCount2);
 
                 CompareParms childParms = new CompareParms
                 {
@@ -75,7 +77,7 @@ namespace KellermanSoftware.CompareNetObjects.TypeComparers
                     object objectValue2 = null;
 
                     if (i < indexerCount2)
-                        objectValue2 = info.PropertyInfo.GetValue(parms.Object2, new object[] { i });
+                        objectValue2 = secondObjectInfo.PropertyInfo.GetValue(parms.Object2, new object[] { i });
 
                     CompareParms childParms = new CompareParms
                     {
@@ -99,7 +101,7 @@ namespace KellermanSoftware.CompareNetObjects.TypeComparers
                     for (int j = indexerCount1; j < indexerCount2; j++)
                     {
                         currentCrumb = AddBreadCrumb(parms.Config, parms.BreadCrumb, info.Name, string.Empty, j);
-                        object objectValue2 = info.PropertyInfo.GetValue(parms.Object2, new object[] { j });
+                        object objectValue2 =  secondObjectInfo.PropertyInfo.GetValue(parms.Object2, new object[] { j });
 
                         CompareParms childParms = new CompareParms
                         {
@@ -121,21 +123,23 @@ namespace KellermanSoftware.CompareNetObjects.TypeComparers
             }
         }
 
-        private bool IndexersHaveDifferentLength(CompareParms parms, PropertyEntity info)
+        private bool IndexersHaveDifferentLength(CompareParms parms, PropertyEntity info, PropertyEntity secondObjectInfo)
         {
             if (info == null)
                 throw new ArgumentNullException("info");
 
 #if !NETSTANDARD
             var type = info.ReflectedType;
+            var type2 = secondObjectInfo.ReflectedType;
 #else
             var type = info.DeclaringType;
+            var type2 = secondObjectInfo.DeclaringType;
 #endif
-            if (type == null)
+            if (type == null || type2 == null)
                 throw new ArgumentNullException("info");
 
             int indexerCount1 = (int)type.GetProperty("Count").GetGetMethod().Invoke(parms.Object1, new object[] { });
-            int indexerCount2 = (int)type.GetProperty("Count").GetGetMethod().Invoke(parms.Object2, new object[] { });
+            int indexerCount2 = (int)type2.GetProperty("Count").GetGetMethod().Invoke(parms.Object2, new object[] { });
 
             if (indexerCount1 != indexerCount2)
             {

--- a/Compare-NET-Objects/TypeComparers/PropertyComparer.cs
+++ b/Compare-NET-Objects/TypeComparers/PropertyComparer.cs
@@ -85,7 +85,7 @@ namespace KellermanSoftware.CompareNetObjects.TypeComparers
             }
             else
             {
-                _indexerComparer.CompareIndexer(parms, info);
+                _indexerComparer.CompareIndexer(parms, info, secondObjectInfo);
                 return;
             }
 


### PR DESCRIPTION
`IndexerComparer.CompareIndexer` threw an exception when comparing `IList` of different types. My real-world case happened on a comparison between a `PersistentGenericList` from NHibernate and a regular `List`. This happened because the indexerCount2 variable was created from the object1 type. That works fine if object1 and object2 are of the same type, but caused a TargetException otherwise.

I fixed it by addding a parameter for the second object `PropertyEntity` to `IndexerComparer.CompareIndexer`.

A test (`CompareListsTwoDifferentListTypes`) is included.