### PR TITLE
addition of IgnoreProperty

### DIFF
--- a/Compare-NET-Objects-Tests/IgnoreTests.cs
+++ b/Compare-NET-Objects-Tests/IgnoreTests.cs
@@ -27,6 +27,52 @@ namespace KellermanSoftware.CompareNetObjectsTests
         }
 
         [Test]
+        public void IgnoreTypeMemberUsingIgnoreProperty()
+        {
+            ComparisonConfig config = new ComparisonConfig();
+            config.IgnoreProperty<Person>(x => x.Name);
+
+            Person person1 = new Person() { Name = "Darth Vader" };
+            Person person2 = new Person() { Name = "Anakin Skywalker" };
+
+            CompareLogic compare = new CompareLogic(config);
+
+            var result = compare.Compare(person1, person2);
+            Assert.IsTrue(result.AreEqual);
+        }
+
+        [Test]
+        public void IgnoreUnaryTypeMemberUsingIgnoreProperty()
+        {
+            ComparisonConfig config = new ComparisonConfig();
+            config.IgnoreProperty<Person>(x => x.DateModified);
+
+            Person person1 = new Person() { DateModified = new DateTime(2019, 5, 23) };
+            Person person2 = new Person() { DateModified = new DateTime(2015, 1, 2)};
+
+            CompareLogic compare = new CompareLogic(config);
+
+            var result = compare.Compare(person1, person2);
+            Assert.IsTrue(result.AreEqual);
+        }
+
+        [Test]
+        public void UsingIgnorePropertyThrowsWithField()
+        {
+            ComparisonConfig config = new ComparisonConfig();
+            Assert.Throws<ArgumentException>(() =>
+                config.IgnoreProperty<Person>(x => x.DateCreated));
+        }
+
+        [Test]
+        public void UsingIgnorePropertyThrowsWithMethod()
+        {
+            ComparisonConfig config = new ComparisonConfig();
+            Assert.Throws<ArgumentException>(() =>
+                config.IgnoreProperty<Person>(x => x.GetAge()));
+        }
+
+        [Test]
         public void ExpandoObject()
         {
             DynamicContainer a = new DynamicContainer()

--- a/Compare-NET-Objects-Tests/TestClasses/Person.cs
+++ b/Compare-NET-Objects-Tests/TestClasses/Person.cs
@@ -17,8 +17,19 @@ namespace KellermanSoftware.CompareNetObjectsTests.TestClasses
             set;
         }
 
+        public DateTime DateModified
+        {
+            get;
+            set;
+        }
+
         public string LastName { get; set; }
 
         public int Age { get; set; }
+
+        public int GetAge()
+        {
+            return Age;
+        }
     }
 }


### PR DESCRIPTION
As discussed in https://github.com/GregFinzer/Compare-Net-Objects/issues/120#issuecomment-493435003 last week. Let me know if you'd like anything modified with this pull request, or if you have questions.  Only implemented for properties as it's likely to be the most common case (implementing for fields too would be a nice bonus... I'll leave that as an exercise for others if they want it) 