### PR TITLE
Add a generic type comparer for easy-to-use.

### DIFF
--- a/Compare-NET-Objects-Tests/CustomComparerTests.cs
+++ b/Compare-NET-Objects-Tests/CustomComparerTests.cs
@@ -35,6 +35,40 @@ namespace KellermanSoftware.CompareNetObjectsTests
             Assert.IsFalse(compareLogic.Compare(tenant1, tenant2).AreEqual);
         }
 
+        [Test]
+        public void UseFuncCustomComparer()
+        {
+
+            CompareLogic compareLogic = new CompareLogic();
+
+            SpecificTenant tenant1 = new SpecificTenant();
+            tenant1.Name = "wire";
+            tenant1.Amount = 37;
+
+            SpecificTenant tenant2 = new SpecificTenant();
+            tenant2.Name = "wire";
+            tenant2.Amount = 155;
+
+            //No Custom Comparer
+            Assert.IsFalse(compareLogic.Compare(tenant1, tenant2).AreEqual);
+
+            //specify custom selector
+            //using the same rule as MyCustomComparer
+            compareLogic.Config.CustomComparers.Add(new CustomComparer<SpecificTenant, SpecificTenant>(
+                (st1, st2) => !(st1.Name != st2.Name || st1.Amount > 100 || st2.Amount < 100)
+            ));
+
+            Assert.IsTrue(compareLogic.Compare(tenant1, tenant2).AreEqual);
+
+            tenant2.Amount = 42;
+            Assert.IsFalse(compareLogic.Compare(tenant1, tenant2).AreEqual);
+
+            //Change rule at runtime
+            var comparerer = compareLogic.Config.CustomComparers[0] as CustomComparer<SpecificTenant, SpecificTenant>;
+            comparerer.Compare = (st1, st2) => !(st1.Name != st2.Name || st1.Amount > 100 || st2.Amount < 40);
+            Assert.IsTrue(compareLogic.Compare(tenant1, tenant2).AreEqual);
+        }
+
 
     }
 }

--- a/Compare-NET-Objects/TypeComparers/CustomComparer.cs
+++ b/Compare-NET-Objects/TypeComparers/CustomComparer.cs
@@ -1,0 +1,70 @@
+﻿using System;
+
+namespace KellermanSoftware.CompareNetObjects.TypeComparers
+{
+    /// <summary>
+    /// Compare two generic objects
+    /// </summary>
+    /// <typeparam name="T1">The type of the first object</typeparam>
+    /// <typeparam name="T2">The type of the second object</typeparam>
+    public class CustomComparer<T1, T2> : BaseTypeComparer
+    {
+        /// <summary>
+        /// Method to evaluate the results, return true if two objects are equal
+        /// </summary>
+        public Func<T1, T2, bool> Compare = (t1, t2) => false;
+
+        /// <summary>
+        /// Constructor that takes a root comparer
+        /// </summary>
+        /// <param name="rootComparer"></param>
+        public CustomComparer(RootComparer rootComparer) : base(rootComparer)
+        {
+        }
+
+        /// <summary>
+        /// Constructor that takes a default root comparer
+        /// </summary>
+        public CustomComparer() : this(RootComparerFactory.GetRootComparer())
+        {
+        }
+
+        /// <summary>
+        /// Constructor that takes a the predication with a default root comparer
+        /// </summary>
+        /// <param name="compare">A function to determine if two objects are equal</param>
+        public CustomComparer(Func<T1, T2, bool> compare) : this(RootComparerFactory.GetRootComparer(), compare)
+        {
+        }
+
+        /// <summary>
+        /// Constructor that takes a the predication with a root comparer
+        /// </summary>
+        /// <param name="rootComparer">The root comparer</param>
+        /// <param name="compare">Method to determine if two objects are equal</param>
+        public CustomComparer(RootComparer rootComparer, Func<T1, T2, bool> compare) : this(rootComparer)
+        {
+            Compare = compare;
+        }
+        /// <summary>
+        /// Compare two objects
+        /// </summary>
+        public override void CompareType(CompareParms parms)
+        {
+            if (!Compare((T1)parms.Object1, (T2)parms.Object2))
+            {
+                AddDifference(parms);
+            }
+        }
+        /// <summary>
+        /// Returns true if both objects match their types
+        /// </summary>
+        /// <param name="type1">The type of the first object</param>
+        /// <param name="type2">The type of the second object</param>
+        /// <returns></returns>
+        public override bool IsTypeMatch(Type type1, Type type2)
+        {
+            return type1 == typeof(T1) && type2 == typeof(T2);
+        }
+    }
+}


### PR DESCRIPTION
Add a generic type custom comparer that can be used inline for most common cases.
Allow dynamically define the compare rule.

Use the `Compare` field to set the predication. 