### PR TITLE
Dictionary Comparer compares by keys

### DIFF
--- a/Compare-NET-Objects-Tests/CompareDictionaryTests.cs
+++ b/Compare-NET-Objects-Tests/CompareDictionaryTests.cs
@@ -15,8 +15,6 @@ namespace KellermanSoftware.CompareNetObjectsTests
 
         #region Setup/Teardown
 
-
-
         /// <summary>
         /// Code that is run before each test
         /// </summary>
@@ -57,12 +55,7 @@ namespace KellermanSoftware.CompareNetObjectsTests
 
             if (!result.AreEqual)
                 throw new Exception(result.DifferencesString);
-
         }
-
-
-
-
 
         [Test]
         public void TestDictionaryNegative()
@@ -82,8 +75,67 @@ namespace KellermanSoftware.CompareNetObjectsTests
 
             dict2["1002"].DateCreated = DateTime.Now.AddDays(1);
 
-            Assert.IsFalse(_compare.Compare(dict1, dict2).AreEqual);
+            var result = _compare.Compare(dict1, dict2);
 
+            Assert.IsFalse(result.AreEqual);
+        }
+
+        [Test]
+        public void TestNullDictionary()
+        {
+            _compare.Config.MaxDifferences = 10;
+
+            Person p1 = new Person();
+            p1.DateCreated = DateTime.Now;
+            p1.Name = "Owen";
+
+            Person p2 = new Person();
+            p2.Name = "Greg";
+            p2.DateCreated = DateTime.Now.AddDays(-1);
+
+            Dictionary<string, Person> dict1 = null;
+
+            Dictionary<string, Person> dict2 = new Dictionary<string, Person>();
+            dict2.Add("1001", p1);
+            dict2.Add("1002", p1);
+            dict2.Add("1003", p1);
+
+            ComparisonResult result1 = _compare.Compare(dict1, dict2);
+            ComparisonResult result2 = _compare.Compare(dict2, dict1);
+
+            Assert.IsFalse(result1.AreEqual);
+            Assert.AreEqual(4, result1.Differences.Count);
+
+            Assert.IsFalse(result2.AreEqual);
+            Assert.AreEqual(4, result2.Differences.Count);
+        }
+
+        [Test]
+        public void TestDictionaryKeysNotAddedInOrder()
+        {
+            _compare.Config.MaxDifferences = 10;
+
+            Person p2 = new Person();
+            p2.Name = "Greg";
+            p2.DateCreated = DateTime.Now.AddDays(-1);
+            Person p3 = new Person();
+            p3.Name = "Martha";
+            p3.DateCreated = DateTime.Now.AddDays(-1);
+
+            Dictionary<string, Person> dict1 = new Dictionary<string, Person>();
+            Dictionary<string, Person> dict2 = new Dictionary<string, Person>();
+
+            dict1.Add("1005", p2);
+
+            dict1.Add("1006", p3);
+            dict2.Add("1006", p3);
+
+            dict2.Add("1005", p2);
+
+            ComparisonResult result = _compare.Compare(dict1, dict2);
+
+            if (!result.AreEqual)
+                throw new Exception(result.DifferencesString);
         }
         #endregion
     }

--- a/Compare-NET-Objects-Tests/IgnoreOrderTests.cs
+++ b/Compare-NET-Objects-Tests/IgnoreOrderTests.cs
@@ -886,8 +886,8 @@ namespace KellermanSoftware.CompareNetObjectsTests
             dict2.Add("1003", p3);
             dict2.Add("1004", p4);
 
-            Assert.IsFalse(_compare.Compare(dict1, dict2).AreEqual);
-            Assert.IsFalse(_compare.Compare(dict2, dict1).AreEqual);
+            Assert.IsTrue(_compare.Compare(dict1, dict2).AreEqual);
+            Assert.IsTrue(_compare.Compare(dict2, dict1).AreEqual);
         }
 
         [Test]


### PR DESCRIPTION
The dictionary comparer would only work if the keys were in the same order (see `TestDictionaryKeysNotAddedInOrder`). That's why I refactored it so it will use Dictionary keys instead of enumerators. This also means the `IgnoreOrderLogic` could be removed, as this is now the default behavior.

Also the comparer adds differences even if one of the sides is null, or if one of the keys is null.

This might be considered a breaking change as the comparer behaves differently.

To fix my Post Processing (#173) issue, I think I will just implement a custom report that builds on this change.