### PR TITLE
177 ignore inherited properties

### DIFF
--- a/Compare-NET-Objects-Tests/IgnoreTests.cs
+++ b/Compare-NET-Objects-Tests/IgnoreTests.cs
@@ -8,92 +8,134 @@ using NUnit.Framework;
 
 namespace KellermanSoftware.CompareNetObjectsTests
 {
-    [TestFixture]
-    public class IgnoreTests
-    {
-        [Test]
-        public void IgnoreTypeMember()
-        {
-            ComparisonConfig config = new ComparisonConfig();
-            config.MembersToIgnore.Add("Person.Name");
+	[TestFixture]
+	public class IgnoreTests
+	{
+		[Test]
+		public void IgnoreTypeMember()
+		{
+			var config = new ComparisonConfig();
+			config.MembersToIgnore.Add("Person.Name");
 
-            Person person1 = new Person() {Name = "Darth Vader"};
-            Person person2 = new Person() {Name = "Anakin Skywalker"};
+			var person1 = new Person {Name = "Darth Vader"};
+			var person2 = new Person {Name = "Anakin Skywalker"};
 
-            CompareLogic compare = new CompareLogic(config);
+			var compare = new CompareLogic(config);
 
-            var result = compare.Compare(person1, person2);
-            Assert.IsTrue(result.AreEqual);
-        }
+			var result = compare.Compare(person1, person2);
+			Assert.IsTrue(result.AreEqual);
+		}
 
-        [Test]
-        public void IgnoreTypeMemberUsingIgnoreProperty()
-        {
-            ComparisonConfig config = new ComparisonConfig();
-            config.IgnoreProperty<Person>(x => x.Name);
+		[Test]
+		public void IgnoreTypeMemberUsingIgnoreProperty()
+		{
+			var config = new ComparisonConfig();
+			config.IgnoreProperty<Person>(x => x.Name);
 
-            Person person1 = new Person() { Name = "Darth Vader" };
-            Person person2 = new Person() { Name = "Anakin Skywalker" };
+			var person1 = new Person { Name = "Darth Vader" };
+			var person2 = new Person { Name = "Anakin Skywalker" };
 
-            CompareLogic compare = new CompareLogic(config);
+			var compare = new CompareLogic(config);
 
-            var result = compare.Compare(person1, person2);
-            Assert.IsTrue(result.AreEqual);
-        }
+			var result = compare.Compare(person1, person2);
+			Assert.IsTrue(result.AreEqual);
+		}
 
-        [Test]
-        public void IgnoreUnaryTypeMemberUsingIgnoreProperty()
-        {
-            ComparisonConfig config = new ComparisonConfig();
-            config.IgnoreProperty<Person>(x => x.DateModified);
+		[Test]
+		public void IgnoreUnaryTypeMemberUsingIgnoreProperty()
+		{
+			var config = new ComparisonConfig();
+			config.IgnoreProperty<Person>(x => x.DateModified);
 
-            Person person1 = new Person() { DateModified = new DateTime(2019, 5, 23) };
-            Person person2 = new Person() { DateModified = new DateTime(2015, 1, 2)};
+			var person1 = new Person { DateModified = new DateTime(2019, 5, 23) };
+			var person2 = new Person { DateModified = new DateTime(2015, 1, 2)};
 
-            CompareLogic compare = new CompareLogic(config);
+			var compare = new CompareLogic(config);
 
-            var result = compare.Compare(person1, person2);
-            Assert.IsTrue(result.AreEqual);
-        }
+			var result = compare.Compare(person1, person2);
+			Assert.IsTrue(result.AreEqual);
+		}
 
-        [Test]
-        public void UsingIgnorePropertyThrowsWithField()
-        {
-            ComparisonConfig config = new ComparisonConfig();
-            Assert.Throws<ArgumentException>(() =>
-                config.IgnoreProperty<Person>(x => x.DateCreated));
-        }
+		[Test]
+		public void UsingIgnorePropertyThrowsWithField()
+		{
+			var config = new ComparisonConfig();
+			Assert.Throws<ArgumentException>(() =>
+				config.IgnoreProperty<Person>(x => x.DateCreated));
+		}
 
-        [Test]
-        public void UsingIgnorePropertyThrowsWithMethod()
-        {
-            ComparisonConfig config = new ComparisonConfig();
-            Assert.Throws<ArgumentException>(() =>
-                config.IgnoreProperty<Person>(x => x.GetAge()));
-        }
+		[Test]
+		public void UsingIgnorePropertyThrowsWithMethod()
+		{
+			var config = new ComparisonConfig();
+			Assert.Throws<ArgumentException>(() =>
+				config.IgnoreProperty<Person>(x => x.GetAge()));
+		}
 
-        [Test]
-        public void ExpandoObject()
-        {
-            DynamicContainer a = new DynamicContainer()
-            {
-                expando = JsonConvert.DeserializeObject<ExpandoObject>("{\"test\": \"1\"}")
-            };
+		[Test]
+		public void ExpandoObject()
+		{
+			var a = new DynamicContainer
+			{
+				expando = JsonConvert.DeserializeObject<ExpandoObject>("{\"test\": \"1\"}")
+			};
 
-            DynamicContainer b = new DynamicContainer()
-            {
-                expando = JsonConvert.DeserializeObject<ExpandoObject>("{\"test\": \"2\"}")
-            };
+			var b = new DynamicContainer
+			{
+				expando = JsonConvert.DeserializeObject<ExpandoObject>("{\"test\": \"2\"}")
+			};
 
-            CompareLogic compareLogic = new CompareLogic();
-            compareLogic.Config.MembersToIgnore.Add("test");
-            compareLogic.Config.CustomComparers.Add(new StringMightBeFloat(RootComparerFactory.GetRootComparer()));
-            compareLogic.Config.MaxDifferences = 50;
+			var compareLogic = new CompareLogic();
+			compareLogic.Config.MembersToIgnore.Add("test");
+			compareLogic.Config.CustomComparers.Add(new StringMightBeFloat(RootComparerFactory.GetRootComparer()));
+			compareLogic.Config.MaxDifferences = 50;
 
-            ComparisonResult result = compareLogic.Compare(a, b);
+			var result = compareLogic.Compare(a, b);
 
-            Console.WriteLine(result.DifferencesString);
-            Assert.IsTrue(result.AreEqual);
-        }
-    }
+			Console.WriteLine(result.DifferencesString);
+			Assert.IsTrue(result.AreEqual);
+		}
+
+		[Test]
+		public void IgnoreBaseClassPropertyUsingIgnoreProperty()
+		{
+			var config = new ComparisonConfig();
+			config.IgnoreProperty<Officer>(x => x.ID);
+
+			var deriveFromOfficer1 = new DeriveFromOfficer {HomeAddress = "Address", ID = 1, Name = "John", Type = Deck.Engineering};
+			var deriveFromOfficer2 = new DeriveFromOfficer {HomeAddress = "Address", ID = 2, Name = "John", Type = Deck.Engineering};
+
+			var derive2FromOfficer1 = new Derive2FromOfficer { Email = "a@a.com", ID = 3, Name = "John", Type = Deck.Engineering };
+			var derive2FromOfficer2 = new Derive2FromOfficer { Email = "a@a.com", ID = 4, Name = "John", Type = Deck.Engineering };
+
+			var compare = new CompareLogic(config);
+
+			var result = compare.Compare(deriveFromOfficer1, deriveFromOfficer2);
+			Assert.IsTrue(result.AreEqual);
+
+			result = compare.Compare(derive2FromOfficer1, derive2FromOfficer2);
+			Assert.IsTrue(result.AreEqual);
+		}
+
+		[Test]
+		public void IgnoreDerivedClassPropertyUsingIgnoreProperty()
+		{
+			var config = new ComparisonConfig();
+			config.IgnoreProperty<DeriveFromOfficer>(x => x.ID);
+
+			var deriveFromOfficer1 = new DeriveFromOfficer { HomeAddress = "Address", ID = 1, Name = "John", Type = Deck.Engineering };
+			var deriveFromOfficer2 = new DeriveFromOfficer { HomeAddress = "Address", ID = 2, Name = "John", Type = Deck.Engineering };
+
+			var derive2FromOfficer1 = new Derive2FromOfficer { Email = "a@a.com", ID = 3, Name = "John", Type = Deck.Engineering };
+			var derive2FromOfficer2 = new Derive2FromOfficer { Email = "a@a.com", ID = 4, Name = "John", Type = Deck.Engineering };
+
+			var compare = new CompareLogic(config);
+
+			var result = compare.Compare((Officer)deriveFromOfficer1, (Officer)deriveFromOfficer2);
+			Assert.IsTrue(result.AreEqual);
+
+			result = compare.Compare(derive2FromOfficer1, derive2FromOfficer2);
+			Assert.IsFalse(result.AreEqual);
+		}
+	}
 }

--- a/Compare-NET-Objects-Tests/TestClasses/Derive2FromOfficer.cs
+++ b/Compare-NET-Objects-Tests/TestClasses/Derive2FromOfficer.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KellermanSoftware.CompareNetObjectsTests.TestClasses
+{
+    public class Derive2FromOfficer : Officer
+    {
+        public string Email { get; set; }
+    }
+}

--- a/Compare-NET-Objects/ExcludeLogic.cs
+++ b/Compare-NET-Objects/ExcludeLogic.cs
@@ -47,8 +47,9 @@ namespace KellermanSoftware.CompareNetObjects
         /// </summary>
         /// <param name="config"></param>
         /// <param name="info"></param>
+        /// <param name="objectType"></param>
         /// <returns></returns>
-        public static bool ShouldExcludeMember(ComparisonConfig config, MemberInfo info)
+        public static bool ShouldExcludeMember(ComparisonConfig config, MemberInfo info, Type objectType)
         {
             //Only compare specific member names
             if (config.MembersToInclude.Count > 0 && !config.MembersToInclude.Contains(info.Name))
@@ -56,8 +57,12 @@ namespace KellermanSoftware.CompareNetObjects
             
             if (config.MembersToIgnore.Count > 0)
             {
-                //Ignore by type.membername
-                if (info.DeclaringType != null
+				//Ignore by objecttype.membername
+	            if (config.MembersToIgnore.Contains(objectType.Name + "." + info.Name))
+		            return true;
+
+				//Ignore by declaringType.membername
+				if (info.DeclaringType != null
                     && config.MembersToIgnore.Contains(info.DeclaringType.Name + "." + info.Name))
                     return true;
 
@@ -177,7 +182,7 @@ namespace KellermanSoftware.CompareNetObjects
         /// <summary>
         /// Check if any type has attributes that should be bypassed
         /// </summary>
-        /// <returns></returns>
+        /// <returns></returns>	
         public static bool IgnoredByAttribute(ComparisonConfig config, MemberInfo info)
         {
             var attributes = info.GetCustomAttributes(true);

--- a/Compare-NET-Objects/TypeComparers/FieldComparer.cs
+++ b/Compare-NET-Objects/TypeComparers/FieldComparer.cs
@@ -44,7 +44,7 @@ namespace KellermanSoftware.CompareNetObjects.TypeComparers
                 return;
 
             //Skip if it should be excluded based on the configuration
-            if (ExcludeLogic.ShouldExcludeMember(parms.Config, item))
+            if (ExcludeLogic.ShouldExcludeMember(parms.Config, item, parms.Object1Type))
                 return;
 
             //If we ignore types then we must get correct FieldInfo object

--- a/Compare-NET-Objects/TypeComparers/PropertyComparer.cs
+++ b/Compare-NET-Objects/TypeComparers/PropertyComparer.cs
@@ -61,7 +61,7 @@ namespace KellermanSoftware.CompareNetObjects.TypeComparers
                 return;
 
             //Skip if it should be excluded based on the configuration
-            if (info.PropertyInfo != null && ExcludeLogic.ShouldExcludeMember(parms.Config, info.PropertyInfo))
+            if (info.PropertyInfo != null && ExcludeLogic.ShouldExcludeMember(parms.Config, info.PropertyInfo, info.DeclaringType))
                 return;
 
             //This is a dynamic property to be excluded on an expando object


### PR DESCRIPTION
Added to ExcludeLogic.ShouldExcludeMember an extra argument which the type of the object that we want the property to be compared

With this change, I kept the backward compatibility with the current implementation. 