### PR TITLE
Added a new option to ignore DateTimeOffset timezones

### DIFF
--- a/Compare-NET-Objects-Tests/CompareDateTimeOffsets.cs
+++ b/Compare-NET-Objects-Tests/CompareDateTimeOffsets.cs
@@ -82,6 +82,36 @@ namespace KellermanSoftware.CompareNetObjectsTests
             if (!result.AreEqual)
                 throw new Exception(result.DifferencesString);
         }
+
+        [Test]
+        public void DateTimeOffsetIgnoreTimezoneEqual()
+        {
+            DateTimeOffset date = new DateTimeOffset(DateTime.Now);
+            DateTimeOffset date1 = TimeZoneInfo.ConvertTime(date, CentralEuropeStandardTime);
+            DateTimeOffset date2 = TimeZoneInfo.ConvertTime(date, SingaporeStandardTime);
+
+            _compare.Config.IgnoreDateTimeOffsetTimezones = true;
+            ComparisonResult result = _compare.Compare(date1, date2);
+
+            Assert.IsTrue(result.AreEqual);
+        }
+
+        [Test]
+        public void DateTimeOffsetIgnoreTimezoneNotEqual()
+        {
+            DateTimeOffset date = new DateTimeOffset(DateTime.Now);
+            DateTimeOffset date1 = TimeZoneInfo.ConvertTime(date, CentralEuropeStandardTime);
+            DateTimeOffset date2 = TimeZoneInfo.ConvertTime(date.AddSeconds(2), SingaporeStandardTime);
+
+            _compare.Config.IgnoreDateTimeOffsetTimezones = true;
+            ComparisonResult result = _compare.Compare(date1, date2);
+
+            Assert.IsFalse(result.AreEqual);
+        }
+
+        private static TimeZoneInfo CentralEuropeStandardTime = TimeZoneInfo.FindSystemTimeZoneById("Central Europe Standard Time");
+        private static TimeZoneInfo SingaporeStandardTime = TimeZoneInfo.FindSystemTimeZoneById("Singapore Standard Time");
+
         #endregion
     }
 }

--- a/Compare-NET-Objects/ComparisonConfig.cs
+++ b/Compare-NET-Objects/ComparisonConfig.cs
@@ -68,6 +68,15 @@ namespace KellermanSoftware.CompareNetObjects
 #endif
         public bool CompareDateTimeOffsetWithOffsets  { get; set; }
 
+
+        /// <summary>
+        /// When comparing DateTimeOffsets, timezone difference will be ignored by changing both object to their UTC equivalent value. The default is false.
+        /// </summary>
+#if !NETSTANDARD
+        [DataMember]
+#endif
+        public bool IgnoreDateTimeOffsetTimezones { get; set; }
+
         /// <summary>
         /// When comparing struct, the depth to compare for children.  The default is 2, the max is 5
         /// </summary>

--- a/Compare-NET-Objects/TypeComparers/DateTimeOffsetComparer.cs
+++ b/Compare-NET-Objects/TypeComparers/DateTimeOffsetComparer.cs
@@ -39,6 +39,12 @@ namespace KellermanSoftware.CompareNetObjects.TypeComparers
             DateTimeOffset date1 = (DateTimeOffset)parms.Object1;
             DateTimeOffset date2 = (DateTimeOffset)parms.Object2;
 
+            if (parms.Config.IgnoreDateTimeOffsetTimezones)
+            {
+                date1 = date1.ToUniversalTime();
+                date2 = date2.ToUniversalTime();
+            }
+
             if (parms.Config.CompareDateTimeOffsetWithOffsets 
                 && Math.Abs((date1 - date2).TotalMilliseconds) > parms.Config.MaxMillisecondsDateDifference)
             {
@@ -57,7 +63,6 @@ namespace KellermanSoftware.CompareNetObjects.TypeComparers
                     AddDifference(parms);
                 }
             }
-
         }
     }
 }


### PR DESCRIPTION
DateTimeOffset may have the same time value however set in different timezones, e.g.
10/10/2019 01:00:00 +02:00 CEST is equivalent to 10/10/2019 07:00:00 +08:00 Singapore time

My case scenario which I am trying to solve is that I create an object with UTC, save it to database and the EfCore library for PostgresSQL retrieves the DateTimeOffset using my local time (which is +02:00 right now).