### PR TITLE
Decimal nullable on collection187 issue

### DIFF
--- a/Compare-NET-Objects-Tests/CompareDecimalTests.cs
+++ b/Compare-NET-Objects-Tests/CompareDecimalTests.cs
@@ -3,6 +3,11 @@ using NUnit.Framework;
 
 namespace KellermanSoftware.CompareNetObjectsTests
 {
+    internal class TestClass
+    {
+        public decimal? DecimalValue { get; set; }
+    }
+
     [TestFixture]
     public class CompareDecimalTests
     {
@@ -11,8 +16,6 @@ namespace KellermanSoftware.CompareNetObjectsTests
         #endregion
 
         #region Setup/Teardown
-
-
 
         /// <summary>
         /// Code that is run before each test
@@ -48,6 +51,29 @@ namespace KellermanSoftware.CompareNetObjectsTests
 
             var result = _compare.Compare(value1, value2);
             Assert.AreEqual(expectedResult, result.AreEqual);
+        }
+
+        [TestCase("1.1", "1.10", 0, true)]
+        [TestCase("1.11", "1.10", 0, false)]
+        [TestCase("1.11", "1.10", 0.1, true)]
+        [TestCase("1.2", "1.1", 0.1, false)]
+        [TestCase("1.10", "1.1", 0.01, true)]
+        [TestCase("1.10", "1.11", 0.001, false)]
+        [TestCase("1.100", "1.110", 0.001, false)]
+        [TestCase("1.110", "1.11", 0.001, true)]
+        public void CompareDecimalNullableInComplexCollectionTest(decimal? value1, decimal? value2, decimal precision, bool expectedResult)
+        {
+            if (precision > 0)
+            {
+                _compare.Config.IgnoreCollectionOrder = true;
+                _compare.Config.DecimalPrecision = precision;
+            }
+
+            var test1 = new[] { new TestClass { DecimalValue = value1 } };
+            var test2 = new[] { new TestClass { DecimalValue = value2 } };
+
+            var result = _compare.Compare(test1, test2);
+            Assert.That(result.AreEqual, Is.EqualTo(expectedResult));
         }
     }
 }

--- a/Compare-NET-Objects/IgnoreOrderTypes/IgnoreOrderLogic.cs
+++ b/Compare-NET-Objects/IgnoreOrderTypes/IgnoreOrderLogic.cs
@@ -44,7 +44,7 @@ namespace KellermanSoftware.CompareNetObjects.IgnoreOrderTypes
             public int Counter;
             public readonly object ObjectValue;
         }
-        
+
         private void CompareOutOfOrder(CompareParms parms, bool reverseCompare)
         {
             IEnumerator enumerator1;
@@ -59,8 +59,8 @@ namespace KellermanSoftware.CompareNetObjects.IgnoreOrderTypes
 
             if (!reverseCompare)
             {
-                enumerator1 = ((IEnumerable) parms.Object1).GetEnumerator();
-                enumerator2 = ((IEnumerable) parms.Object2).GetEnumerator();
+                enumerator1 = ((IEnumerable)parms.Object1).GetEnumerator();
+                enumerator2 = ((IEnumerable)parms.Object2).GetEnumerator();
             }
             else
             {
@@ -89,7 +89,7 @@ namespace KellermanSoftware.CompareNetObjects.IgnoreOrderTypes
             while (enumerator2.MoveNext())
             {
                 var data = enumerator2.Current;
-                if (data != null 
+                if (data != null
                     && parms.Config.ClassTypesToIgnore.Contains(data.GetType()))
                 {
                     continue;
@@ -184,7 +184,6 @@ namespace KellermanSoftware.CompareNetObjects.IgnoreOrderTypes
             }
         }
 
-
         private string GetMatchIndex(ComparisonResult result, List<string> spec, object currentObject)
         {
             if (currentObject == null)
@@ -216,11 +215,12 @@ namespace KellermanSoftware.CompareNetObjects.IgnoreOrderTypes
 
                 if (propertyValue == null)
                 {
-                    sb.AppendFormat("{0}:(null),",item);
+                    sb.AppendFormat("{0}:(null),", item);
                 }
                 else
                 {
-                    string formatString = $"{{0}}:{{1{(info.PropertyType.Name == "Decimal" ? ":N" : string.Empty)}}},";
+                    var decimals = BitConverter.GetBytes(decimal.GetBits(result.Config.DecimalPrecision)[3])[2];
+                    var formatString = $"{{0}}:{{1{(info.PropertyType.FullName != null && info.PropertyType.FullName.Contains("System.Decimal") ? $":N{decimals}" : string.Empty)}}},";
                     sb.Append(string.Format(formatString, item, propertyValue));
                 }
             }
@@ -263,7 +263,7 @@ namespace KellermanSoftware.CompareNetObjects.IgnoreOrderTypes
 #endif
         }
 
-        private List<string> GetMatchingSpec(ComparisonResult result,Type type)
+        private List<string> GetMatchingSpec(ComparisonResult result, Type type)
         {
             if (type == null)
                 return new List<string> { "(null)" };
@@ -279,7 +279,7 @@ namespace KellermanSoftware.CompareNetObjects.IgnoreOrderTypes
             List<string> list = Cache.GetPropertyInfo(result.Config, type)
                 .Where(o => o.CanWrite && (TypeHelper.IsSimpleType(o.PropertyType) || TypeHelper.IsEnum(o.PropertyType)))
                 .Select(o => o.Name).ToList();
-            
+
             //Remove members to ignore in the key
             foreach (var member in result.Config.MembersToIgnore)
             {
@@ -288,17 +288,5 @@ namespace KellermanSoftware.CompareNetObjects.IgnoreOrderTypes
 
             return list;
         }
-
-
-
-
-
-
-
-
-
-
-
-
     }
 }

--- a/Compare-NET-Objects/IgnoreOrderTypes/IgnoreOrderLogic.cs
+++ b/Compare-NET-Objects/IgnoreOrderTypes/IgnoreOrderLogic.cs
@@ -220,7 +220,8 @@ namespace KellermanSoftware.CompareNetObjects.IgnoreOrderTypes
                 else
                 {
                     var decimals = BitConverter.GetBytes(decimal.GetBits(result.Config.DecimalPrecision)[3])[2];
-                    var formatString = $"{{0}}:{{1{(info.PropertyType.FullName != null && info.PropertyType.FullName.Contains("System.Decimal") ? $":N{decimals}" : string.Empty)}}},";
+                    var formatString = $"{{0}}:{{1{(TypeHelper.IsDecimal(propertyValue) ? $":N{decimals}" : string.Empty)}}},";
+
                     sb.Append(string.Format(formatString, item, propertyValue));
                 }
             }

--- a/Compare-NET-Objects/TypeHelper.cs
+++ b/Compare-NET-Objects/TypeHelper.cs
@@ -295,6 +295,19 @@ namespace KellermanSoftware.CompareNetObjects
         }
 
         /// <summary>
+        /// Return true if the type is a Decimal or Nullable Decimal
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static bool IsDecimal(object value)
+        {
+            if (value == null)
+                return false;
+
+            return value is decimal;
+        }
+
+        /// <summary>
         /// Return true if the type is a DateTime
         /// </summary>
         /// <param name="type"></param>


### PR DESCRIPTION
Have changed the compare logic for complex types using IgnoreOrderLogic when comparing complex type collections that contains a object with nullable decimal property. The issue #187 describes more details to reproduce.

Now, logic compares the FullName instead of Name and apply decimal formatting based on DecimalPrecision configuration that wasn't beeing applyed.

Added in CompareDecimalTests some new cases that grants this issue dont come back in future maintenances.

None other main logic was changed, just IgnoreOrderLogic.

Added IsDecimal(object value) in TypeHelper class and passing parameterValue to identify if parameter is a decimal type

FIXES #187 #188 