### PR TITLE
Improve IgnoredByAttribute performance

### DIFF
--- a/Compare-NET-Objects/ExcludeLogic.cs
+++ b/Compare-NET-Objects/ExcludeLogic.cs
@@ -185,6 +185,12 @@ namespace KellermanSoftware.CompareNetObjects
         /// <returns></returns>	
         public static bool IgnoredByAttribute(ComparisonConfig config, MemberInfo info)
         {
+            //Prevent loading attributes when AttributesToIgnore is empty
+            if (config.AttributesToIgnore.Count == 0)
+            {
+                return false;
+            }
+            
             var attributes = info.GetCustomAttributes(true);
 
             return attributes.Any(a => config.AttributesToIgnore.Contains(a.GetType()));


### PR DESCRIPTION
Most of the `CompareProperty` time is spent in `GetCustomAttributes`. Yet this call is unneeded when `AttributesToIgnore` is empty.

![image](https://user-images.githubusercontent.com/1525572/78982553-ac6ab400-7b22-11ea-929a-7064c0583691.png)

The goal of this PR is simply to avoid useless invocations of `GetCustomAttributes`.
