### PR TITLE
Ignore properties that don't have a given Attribute

### DIFF
--- a/Compare-NET-Objects-Tests/Attributes/CompareAttribute.cs
+++ b/Compare-NET-Objects-Tests/Attributes/CompareAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace KellermanSoftware.CompareNetObjectsTests.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public sealed class CompareAttribute : Attribute
+    {
+    }
+}

--- a/Compare-NET-Objects-Tests/BugTests.cs
+++ b/Compare-NET-Objects-Tests/BugTests.cs
@@ -708,6 +708,31 @@ namespace KellermanSoftware.CompareNetObjectsTests
         }
 
         [Test]
+        public void IgnoreByLackOfAttribute_test_should_fail_difference_should_be_customer()
+        {
+            // Arrange
+            Shipment shipment1 = CreateShipment();
+            Shipment shipment2 = CreateShipment();
+            shipment2.InsertDate = DateTime.Now; 
+            shipment2.Customer = "Andritz"; // Only Customer has the CompareAttribute on it
+
+            _compare.Config.RequiredAttributesToCompare.Add(typeof(CompareAttribute));
+            _compare.Config.MaxDifferences = int.MaxValue;
+
+            // Act
+            var result = _compare.Compare(shipment1, shipment2);
+
+            // Assert
+            Assert.IsFalse(result.AreEqual);
+            Assert.AreEqual(1, result.Differences.Count);
+            Console.WriteLine(result.DifferencesString);
+            Assert.AreEqual("ADEG", result.Differences[0].Object1Value);
+            Assert.AreEqual("Andritz", result.Differences[0].Object2Value);
+
+            _compare.Config.RequiredAttributesToCompare.Clear();
+        }
+
+        [Test]
         public void WilliamCWarnerTest()
         {
             ILabTest labTest = new LabTest();

--- a/Compare-NET-Objects-Tests/ConfigTests.cs
+++ b/Compare-NET-Objects-Tests/ConfigTests.cs
@@ -160,6 +160,48 @@ namespace KellermanSoftware.CompareNetObjectsTests
         }
         #endregion
 
+        #region IgnoreByLackOfAttributeTest
+        [Test]
+        public void IgnoreByLackOfAttribute()
+        {
+            Movie movie1 = new Movie();
+            movie1.Name = "Mission Impossible 13, Ethan Gets Unlucky";
+            movie1.PaymentForTomCruise = 20000000;
+
+            Movie movie2 = new Movie();
+            movie2.Name = "Mission Impossible 13, Ethan Gets Unlucky";
+            movie2.PaymentForTomCruise = 20000001;
+
+            //The difference for PaymentForTomCruise will be ignored because only Name property is marked with CompareAttribute
+            _compare.Config.RequiredAttributesToCompare.Add(typeof(CompareAttribute));
+            Assert.IsTrue(_compare.Compare(movie1, movie2).AreEqual, $"Compare should result in equal because {nameof(Movie.PaymentForTomCruise)} doesn't have {nameof(CompareAttribute)}");
+
+            _compare.Config.RequiredAttributesToCompare.Clear();
+        }
+
+        [Test]
+        public void IgnoreByLackOfAttributeDifferent()
+        {
+            Movie movie1 = new Movie();
+            movie1.Name = "Mission Impossible 13, Ethan Gets Unlucky";
+            movie1.PaymentForTomCruise = 20000000;
+
+            Movie movie2 = new Movie();
+            movie2.Name = "Mission Impossible 14, Ethan Gets Unlucky";
+            movie2.PaymentForTomCruise = 20000001;
+
+            //The difference for PaymentForTomCruise will be ignored, but not for Name property, because it has CompareAttribute
+            _compare.Config.RequiredAttributesToCompare.Add(typeof(CompareAttribute));
+            _compare.Config.MaxDifferences = 2;
+
+            var result = _compare.Compare(movie1, movie2);
+            Assert.IsFalse(result.AreEqual, $"Compare shouldn't result in equal because {nameof(Movie.Name)} has different values");
+            Assert.IsTrue(result.Differences.Count == 1, $"Only one difference should exist because {nameof(Movie.PaymentForTomCruise)} doesn't have {nameof(CompareAttribute)}");
+
+            _compare.Config.RequiredAttributesToCompare.Clear();
+        }
+        #endregion
+
         #region Ignore Read Only Tests
         [Test]
         public void IgnoreReadOnlyPositive()

--- a/Compare-NET-Objects-Tests/TestClasses/Movie.cs
+++ b/Compare-NET-Objects-Tests/TestClasses/Movie.cs
@@ -8,6 +8,7 @@ namespace KellermanSoftware.CompareNetObjectsTests.TestClasses
 {
     public class Movie : BaseMedia
     {
+        [Compare]
         public string Name { get; set; }
 
         [ExcludeFromEquality]

--- a/Compare-NET-Objects-Tests/TestClasses/Shipment.cs
+++ b/Compare-NET-Objects-Tests/TestClasses/Shipment.cs
@@ -6,6 +6,7 @@ namespace KellermanSoftware.CompareNetObjectsTests.TestClasses
     class Shipment
     {
         public long IdentCode { get; set; }
+        [Compare]
         public String Customer { get; set; }
         [CompareIgnore]
         public DateTime InsertDate { get; set; }

--- a/Compare-NET-Objects/ComparisonConfig.cs
+++ b/Compare-NET-Objects/ComparisonConfig.cs
@@ -382,7 +382,7 @@ namespace KellermanSoftware.CompareNetObjects
         public List<Type> AttributesToIgnore { get; set; }
 
         /// <summary>
-        /// If a class, property or field don't have at least one of the attributes in this list, it will be ignored
+        /// If a property or field don't have at least one of the attributes in this list, it will be ignored
         /// </summary>
         /// <example>RequiredAttributesToCompare.Add(typeof(XmlIgnoreAttribute));</example>
 #if !NETSTANDARD

--- a/Compare-NET-Objects/ComparisonConfig.cs
+++ b/Compare-NET-Objects/ComparisonConfig.cs
@@ -382,6 +382,15 @@ namespace KellermanSoftware.CompareNetObjects
         public List<Type> AttributesToIgnore { get; set; }
 
         /// <summary>
+        /// If a class, property or field don't have at least one of the attributes in this list, it will be ignored
+        /// </summary>
+        /// <example>RequiredAttributesToCompare.Add(typeof(XmlIgnoreAttribute));</example>
+#if !NETSTANDARD
+        [DataMember]
+#endif
+        public List<Type> RequiredAttributesToCompare { get; set; }
+
+        /// <summary>
         /// If true, objects will be compared ignore their type diferences.  The default is false.
         /// </summary>
 #if !NETSTANDARD
@@ -518,6 +527,7 @@ namespace KellermanSoftware.CompareNetObjects
         public void Reset()
         {
             AttributesToIgnore = new List<Type>();
+            RequiredAttributesToCompare = new List<Type>();
             _differenceCallback = d => { };
 
             MembersToIgnore = new List<string>();

--- a/Compare-NET-Objects/ExcludeLogic.cs
+++ b/Compare-NET-Objects/ExcludeLogic.cs
@@ -79,6 +79,9 @@ namespace KellermanSoftware.CompareNetObjects
             if (IgnoredByAttribute(config, info))
                 return true;
 
+            if (IgnoredByLackOfAttribute(config, info))
+                return true;
+
             return false;
         }
 
@@ -148,6 +151,10 @@ namespace KellermanSoftware.CompareNetObjects
             if (IgnoredByAttribute(config, t1.GetTypeInfo()) || IgnoredByAttribute(config, t2.GetTypeInfo()))
                 return true;
 
+            //The class is ignored by lack of required attribute
+            if (IgnoredByLackOfAttribute(config, t1.GetTypeInfo()) || IgnoredByLackOfAttribute(config, t2.GetTypeInfo()))
+                return true;
+
             return false;
         }
 
@@ -194,6 +201,23 @@ namespace KellermanSoftware.CompareNetObjects
             var attributes = info.GetCustomAttributes(true);
 
             return attributes.Any(a => config.AttributesToIgnore.Contains(a.GetType()));
+        }
+
+        /// <summary>
+        /// Check if any type lacks attributes that should be required
+        /// </summary>
+        /// <returns></returns>	
+        public static bool IgnoredByLackOfAttribute(ComparisonConfig config, MemberInfo info)
+        {
+            //Prevent loading attributes when RequiredAttributesToCompare is empty
+            if (config.RequiredAttributesToCompare.Count == 0)
+            {
+                return false;
+            }
+
+            var attributes = info.GetCustomAttributes(true);
+
+            return !attributes.Any(a => config.RequiredAttributesToCompare.Contains(a.GetType()));
         }
 
     }

--- a/Compare-NET-Objects/ExcludeLogic.cs
+++ b/Compare-NET-Objects/ExcludeLogic.cs
@@ -151,10 +151,6 @@ namespace KellermanSoftware.CompareNetObjects
             if (IgnoredByAttribute(config, t1.GetTypeInfo()) || IgnoredByAttribute(config, t2.GetTypeInfo()))
                 return true;
 
-            //The class is ignored by lack of required attribute
-            if (IgnoredByLackOfAttribute(config, t1.GetTypeInfo()) || IgnoredByLackOfAttribute(config, t2.GetTypeInfo()))
-                return true;
-
             return false;
         }
 


### PR DESCRIPTION
ref.: #207 

I took as example the `AttributesToIgnore` property in `ComparisonConfig` class.

Please let me know if anything should be different.