### PR TITLE
Fix issue 199 when string array starts with nulls

### DIFF
--- a/Compare-NET-Objects-Tests/IgnoreOrderTests.cs
+++ b/Compare-NET-Objects-Tests/IgnoreOrderTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using KellermanSoftware.CompareNetObjects;
@@ -1393,6 +1393,24 @@ namespace KellermanSoftware.CompareNetObjectsTests
             var result = compareLogic.Compare(list1, list2);
             Assert.IsTrue(result.AreEqual);
         }
+
+        [Test]
+        public void CompareListsIgnoreOrderFirstElementNull()
+        {
+            var compareLogic = new CompareLogic();
+            compareLogic.Config.IgnoreCollectionOrder = true;
+
+            Assert.DoesNotThrow(() => compareLogic.Compare(new[] {"a", "b"}, new[] {null, "a"}));
+        }
+
+        [Test] 
+        public void CompareListsIgnoreOrderFirstElementNull_Reverse() 
+        { 
+            var compareLogic = new CompareLogic(); 
+            compareLogic.Config.IgnoreCollectionOrder = true; 
+ 
+            Assert.DoesNotThrow(() => compareLogic.Compare(new[] {null, "a"}, new[] {"a", "b"})); 
+        } 
         #endregion
     }
 }

--- a/Compare-NET-Objects/IgnoreOrderTypes/IgnoreOrderLogic.cs
+++ b/Compare-NET-Objects/IgnoreOrderTypes/IgnoreOrderLogic.cs
@@ -57,6 +57,10 @@ namespace KellermanSoftware.CompareNetObjects.IgnoreOrderTypes
             Type dataType1 = null;
             Type dataType2 = null;
 
+            // Determine an explicit fallback to be used if the first element in an enumerable is null.
+            Type fallbackType1 = parms.Object1Type != null ? (parms.Object1Type.IsGenericType ? parms.Object1Type.GetGenericArguments()[0] : parms.Object1Type.GetElementType()) : null;
+            Type fallbackType2 = parms.Object2Type != null ? (parms.Object2Type.IsGenericType ? parms.Object2Type.GetGenericArguments()[0] : parms.Object2Type.GetElementType()) : null;
+
             if (!reverseCompare)
             {
                 enumerator1 = ((IEnumerable)parms.Object1).GetEnumerator();
@@ -77,7 +81,7 @@ namespace KellermanSoftware.CompareNetObjects.IgnoreOrderTypes
                     continue;
                 }
 
-                dataType1 = dataType1 ?? data?.GetType();
+                dataType1 = dataType1 ?? data?.GetType() ?? fallbackType1;
                 matchingSpec1 = matchingSpec1 ?? GetMatchingSpec(parms.Result, dataType1);
                 var matchingIndex = GetMatchIndex(parms.Result, matchingSpec1, data);
                 if (!list1.ContainsKey(matchingIndex))
@@ -95,7 +99,7 @@ namespace KellermanSoftware.CompareNetObjects.IgnoreOrderTypes
                     continue;
                 }
 
-                dataType2 = dataType2 ?? data?.GetType();
+                dataType2 = dataType2 ?? data?.GetType() ?? fallbackType2;
                 matchingSpec2 = matchingSpec2 ?? GetMatchingSpec(parms.Result, dataType2);
                 var matchingIndex = GetMatchIndex(parms.Result, matchingSpec2, data);
                 if (!list2.ContainsKey(matchingIndex))


### PR DESCRIPTION
Closes https://github.com/GregFinzer/Compare-Net-Objects/issues/199

- Added two new tests to ensure null being at the beginning of either array result in NOT throwing an exception for failing due to `Invalid CollectionMatchingSpec`