### PR TITLE
Comparisons on date time objects

### DIFF
--- a/Compare-NET-Objects/TypeComparers/BaseComparer.cs
+++ b/Compare-NET-Objects/TypeComparers/BaseComparer.cs
@@ -164,6 +164,9 @@ namespace KellermanSoftware.CompareNetObjects.TypeComparers
                         return "System.DBNull.Value";
                 #endif
 
+                if(object is DateTime)
+                    return ((DateTime)object).ToString("o");
+                    
                 return value.ToString();
             }
             catch

--- a/Compare-NET-Objects/TypeComparers/BaseComparer.cs
+++ b/Compare-NET-Objects/TypeComparers/BaseComparer.cs
@@ -164,8 +164,8 @@ namespace KellermanSoftware.CompareNetObjects.TypeComparers
                         return "System.DBNull.Value";
                 #endif
 
-                if(object is DateTime)
-                    return ((DateTime)object).ToString("o");
+                if(value is DateTime)
+                    return ((DateTime)value).ToString("o");
                     
                 return value.ToString();
             }


### PR DESCRIPTION
Currently when doing a comparison on a datetime object, the resulting date is a string based on the local machine culture. This makes the library behave differently depending on where it is deployed. A standardized ISO format would make a lot more sense and would make the code platform agnostic.