### PR TITLE
Add Configuration to Treat Missing Members as Differences

### DIFF
--- a/Compare-NET-Objects-Tests/MissingPropertiesTests.cs
+++ b/Compare-NET-Objects-Tests/MissingPropertiesTests.cs
@@ -1,0 +1,100 @@
+﻿using KellermanSoftware.CompareNetObjects;
+using KellermanSoftware.CompareNetObjectsTests.TestClasses;
+using NUnit.Framework;
+using System;
+using System.Linq;
+
+namespace KellermanSoftware.CompareNetObjectsTests
+{
+    [TestFixture]
+    public class MissingMemberTests
+    {
+        private static readonly PersonSummary PersonSummary = new PersonSummary
+        {
+            ID = 1234,
+            Name = "Humpty",
+            LastName = "Dumpty"
+        };
+
+        private static readonly Person Person = new Person
+        {
+            ID = 1234,
+            Name = "Humpty",
+            LastName = "Dumpty",
+            Age = 101,
+            DateCreated = DateTime.Now,
+            DateModified = DateTime.Now
+        };
+
+        [Test]
+        public void ShouldIncludeMissingMembersInDifferencesWhenConfigured()
+        {
+            var testInstance = new CompareLogic();
+            testInstance.Config.IgnoreObjectTypes = true;
+            testInstance.Config.IgnoreMissingProperties = false;
+            testInstance.Config.IgnoreMissingFields = false;
+            testInstance.Config.MaxDifferences = 100;
+
+            var result = testInstance.Compare(
+                Person,
+                PersonSummary);
+
+            Assert.IsFalse(result.AreEqual);
+            Assert
+                .IsTrue(result.Differences.Select(x => x.PropertyName)
+                .Contains(nameof(Person.Age)),
+                "Differences contains the missing Age property");
+            Assert
+                .IsTrue(result.Differences.Select(x => x.PropertyName)
+                .Contains(nameof(Person.DateModified)),
+                "Differences contains the missing DateModified property");
+            Assert
+                .IsTrue(result.Differences.Select(x => x.PropertyName)
+                .Contains(nameof(Person.DateCreated)),
+                "Differences contains the missing DateCreated property");
+        }
+
+        [Test]
+        public void ShouldNotIncludeMissingMembersInDifferencesWhenNotConfigured()
+        {
+            var testInstance = new CompareLogic();
+            testInstance.Config.IgnoreObjectTypes = true;
+            testInstance.Config.MaxDifferences = 100;
+
+            var result = testInstance.Compare(
+                Person,
+                PersonSummary);
+
+            Assert.IsTrue(result.AreEqual);
+        }
+
+        [Test]
+        public void ShouldIncludeMissingMembersInDifferencesUnlessExplicitlyIgnored()
+        {
+            var testInstance = new CompareLogic();
+            testInstance.Config.IgnoreObjectTypes = true;
+            testInstance.Config.IgnoreMissingProperties = false;
+            testInstance.Config.IgnoreMissingFields = false;
+            testInstance.Config.IgnoreProperty<Person>(x => x.DateModified);
+            testInstance.Config.MaxDifferences = 100;
+
+            var result = testInstance.Compare(
+                Person,
+                PersonSummary);
+
+            Assert.IsFalse(result.AreEqual);
+            Assert
+                .IsTrue(result.Differences.Select(x => x.PropertyName)
+                .Contains(nameof(Person.Age)),
+                "Differences contains the missing Age property");
+            Assert
+                .IsFalse(result.Differences.Select(x => x.PropertyName)
+                .Contains(nameof(Person.DateModified)),
+                "Differences does not contain the missing DateModified property as it is explicitly ignored");
+            Assert
+                .IsTrue(result.Differences.Select(x => x.PropertyName)
+                .Contains(nameof(Person.DateCreated)),
+                "Differences contains the missing DateCreated property");
+        }
+    }
+}

--- a/Compare-NET-Objects-Tests/TestClasses/PersonSummary.cs
+++ b/Compare-NET-Objects-Tests/TestClasses/PersonSummary.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KellermanSoftware.CompareNetObjectsTests.TestClasses
+{
+    public class PersonSummary
+    {
+        public int ID { get; set; }
+        public string Name { get; set; }
+        public string LastName { get; set; }
+    }
+}

--- a/Compare-NET-Objects/ComparisonConfig.cs
+++ b/Compare-NET-Objects/ComparisonConfig.cs
@@ -548,6 +548,16 @@ namespace KellermanSoftware.CompareNetObjects
 #endif
         public bool IgnoreConcreteTypes { get; set; }
 
+        /// <summary>
+        /// If true, properties that are defined in the actual object but missing in the expected object will not be flagged as differences. Default is true.
+        /// </summary>
+        public bool IgnoreMissingProperties { get; set; }
+
+        /// <summary>
+        /// If true, fields that are defined in the actual object but missing in the expected object will not be flagged as differences. Default is true.
+        /// </summary>
+        public bool IgnoreMissingFields { get; set; }
+
         #endregion
 
         #region Methods
@@ -631,6 +641,8 @@ namespace KellermanSoftware.CompareNetObjects
             MaxStructDepth = 2;
             CaseSensitive = true;
             IgnoreStringLeadingTrailingWhitespace = false;
+            IgnoreMissingProperties = true;
+            IgnoreMissingFields = true;
         }
 #endregion
     }

--- a/Compare-NET-Objects/TypeComparers/FieldComparer.cs
+++ b/Compare-NET-Objects/TypeComparers/FieldComparer.cs
@@ -50,8 +50,8 @@ namespace KellermanSoftware.CompareNetObjects.TypeComparers
             //If we ignore types then we must get correct FieldInfo object
             FieldInfo secondFieldInfo = GetSecondFieldInfo(parms, item);
 
-            //If the field does not exist, and we are ignoring the object types, skip it
-            if ((parms.Config.IgnoreObjectTypes || parms.Config.IgnoreConcreteTypes) && secondFieldInfo == null)
+            //If the field does not exist, and we are ignoring the object types, skip it - unless we have set IgnoreMissingFields = true
+            if ((parms.Config.IgnoreObjectTypes || parms.Config.IgnoreConcreteTypes) && secondFieldInfo == null && parms.Config.IgnoreMissingFields)
                 return;
 
             object objectValue1 = item.GetValue(parms.Object1);

--- a/Compare-NET-Objects/TypeComparers/PropertyComparer.cs
+++ b/Compare-NET-Objects/TypeComparers/PropertyComparer.cs
@@ -75,8 +75,8 @@ namespace KellermanSoftware.CompareNetObjects.TypeComparers
             //If we ignore types then we must get correct PropertyInfo object
             PropertyEntity secondObjectInfo = GetSecondObjectInfo(info, object2Properties);
 
-            //If the property does not exist, and we are ignoring the object types, skip it
-            if ((parms.Config.IgnoreObjectTypes || parms.Config.IgnoreConcreteTypes) && secondObjectInfo == null)
+            //If the property does not exist, and we are ignoring the object types, skip it - unless we have set IgnoreMissingProperties = true
+            if ((parms.Config.IgnoreObjectTypes || parms.Config.IgnoreConcreteTypes) && secondObjectInfo == null && parms.Config.IgnoreMissingProperties)
                 return;
 
             //Check if we have custom function to validate property


### PR DESCRIPTION
Pull request adds two new configuration options:

- `IgnoreMissingProperties` (default = true)
- `IgnoreMissingFields` (default = true)

When set to false these will cause missing properties / fields (defined in Actual object but missing from Expected) to be treated as differences. By default these will both be true - preserving existing behavior.

### Example

One use-case for this feature is for verifying mapping operations (such as Person -> PersonDto) where we want to verify that all members are equivalent (barring any explicit exclusions).

var person = new Person{ Name = "Humpty", LastName = "Dumpty", Age = 21 };
var personDto = new PersonDto { Name = "Humpty", LastName = "Dumpty" };

var compare = new Compare();
compare .Config.IgnoreObjectTypes = true;
compare .Config.IgnoreMissingProperties = false;

var result = compare.Comapre(person, personDto);

Assert.IsFalse(result.AreEqual); // should be false as personDto is missing property "Age"