### PR TITLE
Take in account DateTime.Kind while comparing

### DIFF
--- a/Compare-NET-Objects-Tests/CompareDateTimeTests.cs
+++ b/Compare-NET-Objects-Tests/CompareDateTimeTests.cs
@@ -60,6 +60,18 @@ namespace KellermanSoftware.CompareNetObjectsTests
             if (!result.AreEqual)
                 throw new Exception(result.DifferencesString);
         }
+
+        [Test]
+        public void TestUtcvsLocalDates()
+        {
+            var dateTimeUtcNow = DateTime.UtcNow;
+            var dateTimeNow = dateTimeUtcNow.ToLocalTime();
+            CompareLogic compareLogic = new CompareLogic();
+
+            ComparisonResult result = compareLogic.Compare(dateTimeNow, dateTimeUtcNow);
+
+            Assert.IsTrue(result.AreEqual);
+        }
         #endregion
     }
 }

--- a/Compare-NET-Objects/Compare-NET-Objects.csproj
+++ b/Compare-NET-Objects/Compare-NET-Objects.csproj
@@ -20,8 +20,8 @@
     <PackageTags>compare comparison equality equal deep objects difference compareobjects deepequal deepequals</PackageTags>
     <Description>What you have been waiting for. Perform a deep compare of any two .NET objects using reflection. Shows the differences between the two objects.</Description>
     <Authors>gfinzer</Authors>
-    <Version>4.74.0</Version>
-    <AssemblyVersion>4.74.0.0</AssemblyVersion>
+    <Version>4.75.0</Version>
+    <AssemblyVersion>4.75.0.0</AssemblyVersion>
     <NeutralLanguage>en-US</NeutralLanguage>    
     <Company>Kellerman Software</Company>
     <PackageReleaseNotes>Support for Nullable DateTimeOffset by goyzhang https://github.com/GregFinzer/Compare-Net-Objects/issues/230
@@ -30,7 +30,7 @@ New config option to IgnoreConcreteTypes by goyzhang  https://github.com/GregFin
 
 Fix for circular references in EnumerableComparer by idealist1508 https://github.com/GregFinzer/Compare-Net-Objects/issues/237</PackageReleaseNotes>
     <Copyright>Copyright © 2022</Copyright>
-    <FileVersion>4.74.0.0</FileVersion>
+    <FileVersion>4.75.0.0</FileVersion>
     
     <PackageLicenseFile>License.txt</PackageLicenseFile>
     <PackageIcon>NuGetIcon.png</PackageIcon>

--- a/Compare-NET-Objects/TypeComparers/DateComparer.cs
+++ b/Compare-NET-Objects/TypeComparers/DateComparer.cs
@@ -39,6 +39,12 @@ namespace KellermanSoftware.CompareNetObjects.TypeComparers
             DateTime date1 = (DateTime) parms.Object1;
             DateTime date2 = (DateTime) parms.Object2;
 
+            if (date1.Kind != date2.Kind)
+            {
+                date1 = date1.ToUniversalTime();
+                date2 = date2.ToUniversalTime();
+            }
+
             if (Math.Abs(date1.Subtract(date2).TotalMilliseconds) > parms.Config.MaxMillisecondsDateDifference)
                 AddDifference(parms);
 


### PR DESCRIPTION
I had the same prolem as the issue in [this link](https://github.com/GregFinzer/Compare-Net-Objects/issues/116) 
I made necessary modifications, and added a unit test for this issue.