### PR TITLE
Handle case when collection contains different concrete types

### DIFF
--- a/Compare-NET-Objects-Tests/IgnoreOrderTests.cs
+++ b/Compare-NET-Objects-Tests/IgnoreOrderTests.cs
@@ -516,6 +516,38 @@ namespace KellermanSoftware.CompareNetObjectsTests
         }
 
         [Test]
+        public void BaseClassCollectionWithIgnoreCollectionOrderTest()
+        {
+            var list1 = new List<Officer>();
+            var list2 = new List<Officer>();
+
+            var officer1 = new DeriveFromOfficer()
+            {
+                ID = 1,
+                Name = "John",
+                Type = Deck.Engineering,
+                HomeAddress = "Address",
+            };
+
+            var officer2 = new Derive2FromOfficer()
+            {
+                ID = 2,
+                Name = "Jill",
+                Type = Deck.AstroPhysics,
+                Email = "a@a.com",
+            };
+
+            list1.Add(officer1);
+            list1.Add(officer2);
+            list2.Add(officer2);
+            list2.Add(officer1);
+
+            _compare.Config.IgnoreCollectionOrder = true;
+
+            Assert.IsTrue(_compare.Compare(list1, list2).AreEqual);
+        }
+
+        [Test]
         public void HashSetsMultipleItemsWithIgnoreCollectionOrderTest()
         {
             HashSetWrapper hashSet1 = new HashSetWrapper

--- a/Compare-NET-Objects/Compare-NET-Objects.csproj
+++ b/Compare-NET-Objects/Compare-NET-Objects.csproj
@@ -20,13 +20,13 @@
     <PackageTags>compare comparison equality equal deep objects difference compareobjects deepequal deepequals</PackageTags>
     <Description>What you have been waiting for. Perform a deep compare of any two .NET objects using reflection. Shows the differences between the two objects.</Description>
     <Authors>gfinzer</Authors>
-    <Version>4.75.0</Version>
-    <AssemblyVersion>4.75.0.0</AssemblyVersion>
+    <Version>4.76.0</Version>
+    <AssemblyVersion>4.76.0.0</AssemblyVersion>
     <NeutralLanguage>en-US</NeutralLanguage>    
     <Company>Kellerman Software</Company>
     <PackageReleaseNotes>Support for DateTime Kinds:  https://github.com/GregFinzer/Compare-Net-Objects/issues/116</PackageReleaseNotes>
     <Copyright>Copyright © 2022</Copyright>
-    <FileVersion>4.75.0.0</FileVersion>
+    <FileVersion>4.76.0.0</FileVersion>
     
     <PackageLicenseFile>License.txt</PackageLicenseFile>
     <PackageIcon>NuGetIcon.png</PackageIcon>

--- a/Compare-NET-Objects/IgnoreOrderTypes/IgnoreOrderLogic.cs
+++ b/Compare-NET-Objects/IgnoreOrderTypes/IgnoreOrderLogic.cs
@@ -54,13 +54,13 @@ namespace KellermanSoftware.CompareNetObjects.IgnoreOrderTypes
 
             IEnumerator enumerator1;
             IEnumerator enumerator2;
-            List<string> matchingSpec1 = null;
-            List<string> matchingSpec2 = null;
 
             var list1 = new Dictionary<string, InstanceCounter>();
             var list2 = new Dictionary<string, InstanceCounter>();
-            Type dataType1 = null;
-            Type dataType2 = null;
+
+            // Store matching spec for each type.
+            var matchingSpec1 = new Dictionary<Type, List<string>>();
+            var matchingSpec2 = new Dictionary<Type, List<string>>();
 
             // Determine an explicit fallback to be used if the first element in an enumerable is null.
             Type fallbackType1 = parms.Object1Type != null ? (TypeHelper.IsGenericType(parms.Object1Type) ? parms.Object1Type.GetGenericArguments()[0] : parms.Object1Type.GetElementType()) : null;
@@ -86,9 +86,11 @@ namespace KellermanSoftware.CompareNetObjects.IgnoreOrderTypes
                     continue;
                 }
 
-                dataType1 = dataType1 ?? data?.GetType() ?? fallbackType1;
-                matchingSpec1 = matchingSpec1 ?? GetMatchingSpec(parms.Result, dataType1);
-                var matchingIndex = GetMatchIndex(parms.Result, matchingSpec1, data);
+                var dataType1 = data?.GetType() ?? fallbackType1;
+                if (!matchingSpec1.ContainsKey(dataType1))
+                    matchingSpec1.Add(dataType1, GetMatchingSpec(parms.Result, dataType1));
+
+                var matchingIndex = GetMatchIndex(parms.Result, matchingSpec1[dataType1], data);
                 if (!list1.ContainsKey(matchingIndex))
                     list1.Add(matchingIndex, new InstanceCounter(data, 1));
                 else
@@ -106,9 +108,11 @@ namespace KellermanSoftware.CompareNetObjects.IgnoreOrderTypes
                     continue;
                 }
 
-                dataType2 = dataType2 ?? data?.GetType() ?? fallbackType2;
-                matchingSpec2 = matchingSpec2 ?? GetMatchingSpec(parms.Result, dataType2);
-                var matchingIndex = GetMatchIndex(parms.Result, matchingSpec2, data);
+                var dataType2 = data?.GetType() ?? fallbackType2;
+                if (!matchingSpec2.ContainsKey(dataType2))
+                    matchingSpec2.Add(dataType2, GetMatchingSpec(parms.Result, dataType2));
+
+                var matchingIndex = GetMatchIndex(parms.Result, matchingSpec2[dataType2], data);
                 if (!list2.ContainsKey(matchingIndex))
                     list2.Add(matchingIndex, new InstanceCounter(data, 1));
                 else


### PR DESCRIPTION
This is a fix for #251. Previously when comparing two lists while ignoring order, the type and matching spec values were always using the first value. The collection may contain different types, so this change now will only try to obtain a new matchingspec if it does not already have one for that type.