### PR TITLE
Handle IEnumerable comparison

### DIFF
--- a/Compare-NET-Objects-Tests/CompareIListTests.cs
+++ b/Compare-NET-Objects-Tests/CompareIListTests.cs
@@ -706,5 +706,28 @@ namespace KellermanSoftware.CompareNetObjectsTests
             Assert.That(comparison.DifferencesString, Does.Contain("Types [Int32,null], Item Expected[3].Item != Actual[3].Item, Values (3,(null))"));
         }
         #endregion
+
+        #region Enumerable Tests
+
+        [Test]
+        public void CompareListsTwoDifferentTypesWithIEnumerable()
+        {
+            List<Person> list1 = new List<Person>();
+            list1.Add(new Person() { Name = "Other name" });
+            list1.Add(new Person() { Name = "Francis 7" });
+
+            HashSet<Officer> list2 = new HashSet<Officer>();
+            list2.Add(new Officer() { Name = "Logan 5" });
+            list2.Add(new Officer() { Name = "Francis 7" });
+
+            ComparisonConfig config = new ComparisonConfig();
+            config.IgnoreObjectTypes = true;
+
+            CompareLogic compareLogic = new CompareLogic(config);
+            var result = compareLogic.Compare(list1, list2);
+            Assert.IsFalse(result.AreEqual);
+        }
+
+        #endregion 
     }
 }

--- a/Compare-NET-Objects-Tests/CompareIndexerTests.cs
+++ b/Compare-NET-Objects-Tests/CompareIndexerTests.cs
@@ -80,8 +80,8 @@ namespace KellermanSoftware.CompareNetObjectsTests
             ComparisonResult result21 = compare.Compare(class2, class1);
 
             // Assert.
-            Assert.AreEqual(result12.Differences.Count, 3);
-            Assert.AreEqual(result21.Differences.Count, 3);
+            Assert.AreEqual(result12.Differences.Count, 1);
+            Assert.AreEqual(result21.Differences.Count, 1);
         }
 
         [Test]

--- a/Compare-NET-Objects-Tests/IgnoreOrderTests.cs
+++ b/Compare-NET-Objects-Tests/IgnoreOrderTests.cs
@@ -711,11 +711,11 @@ namespace KellermanSoftware.CompareNetObjectsTests
             var result = _compare.Compare(class1, class2);
             Console.WriteLine(result.DifferencesString);
 
-            Assert.AreEqual(3, result.Differences.Count);
+            Assert.AreEqual(2, result.Differences.Count);
 
             result = _compare.Compare(class2, class1);
             Console.WriteLine(result.DifferencesString);
-            Assert.AreEqual(3, result.Differences.Count);
+            Assert.AreEqual(2, result.Differences.Count);
 
 
             _compare.Config.MaxDifferences = prior;

--- a/Compare-NET-Objects/RootComparerFactory.cs
+++ b/Compare-NET-Objects/RootComparerFactory.cs
@@ -57,18 +57,19 @@ namespace KellermanSoftware.CompareNetObjects
             _rootComparer.TypeComparers.Add(new DataRowComparer(_rootComparer));
             _rootComparer.TypeComparers.Add(new DataColumnComparer(_rootComparer));
 #endif
-            _rootComparer.TypeComparers.Add(new EnumerableComparer(_rootComparer));
             _rootComparer.TypeComparers.Add(new ByteArrayComparer(_rootComparer));
             _rootComparer.TypeComparers.Add(new DictionaryComparer(_rootComparer));
             _rootComparer.TypeComparers.Add(new HashSetComparer(_rootComparer));
             _rootComparer.TypeComparers.Add(new CollectionComparer(_rootComparer));
+            _rootComparer.TypeComparers.Add(new ImmutableArrayComparer(_rootComparer));
+            _rootComparer.TypeComparers.Add(new EnumerableComparer(_rootComparer));
+
             _rootComparer.TypeComparers.Add(new UriComparer(_rootComparer));
             _rootComparer.TypeComparers.Add(new StringBuilderComparer(_rootComparer));
             _rootComparer.TypeComparers.Add(new ClassComparer(_rootComparer));
             _rootComparer.TypeComparers.Add(new DateTimeOffSetComparer(_rootComparer));
             _rootComparer.TypeComparers.Add(new TimespanComparer(_rootComparer));
             _rootComparer.TypeComparers.Add(new StructComparer(_rootComparer));
-            _rootComparer.TypeComparers.Add(new ImmutableArrayComparer(_rootComparer));
             _rootComparer.TypeComparers.Add(new EnumComparer(_rootComparer));
             return _rootComparer;
         }

--- a/Compare-NET-Objects/TypeHelper.cs
+++ b/Compare-NET-Objects/TypeHelper.cs
@@ -59,10 +59,10 @@ namespace KellermanSoftware.CompareNetObjects
         public static bool IsByteArray(Type type)
         {
             return IsIList(type) && (
-                                     typeof(IEnumerable<byte>).IsAssignableFrom(type) ||
-                                     typeof(IEnumerable<byte?>).IsAssignableFrom(type)
-                                 )
-                                 && type != typeof(sbyte[]);
+                typeof(IEnumerable<byte>).IsAssignableFrom(type) ||
+                typeof(IEnumerable<byte?>).IsAssignableFrom(type)
+                )
+                && type != typeof(sbyte[]);
         }
 
         /// <summary>
@@ -76,19 +76,19 @@ namespace KellermanSoftware.CompareNetObjects
                 return false;
 
             return !IsSimpleType(type)
-                   && !IsTimespan(type)
-                   && !IsDateTimeOffset(type)
-                   && !IsEnum(type)
-                   && !IsPointer(type)
-                   && !IsStringBuilder(type)
-                   && (IsClass(type)
-                       || IsInterface(type)
-                       || IsArray(type)
-                       || IsIDictionary(type)
-                       || IsIList(type)
-                       || IsStruct(type)
-                       || IsHashSet(type)
-                   );
+                && !IsTimespan(type)
+                && !IsDateTimeOffset(type)
+                && !IsEnum(type)
+                && !IsPointer(type)
+                && !IsStringBuilder(type)
+                && (IsClass(type)
+                    || IsInterface(type)
+                    || IsArray(type)
+                    || IsIDictionary(type)
+                    || IsIList(type)
+                    || IsStruct(type)
+                    || IsHashSet(type)
+                    );
         }
 
         /// <summary>
@@ -114,7 +114,7 @@ namespace KellermanSoftware.CompareNetObjects
             if (type == null)
                 return false;
 
-            return type.Namespace == "System.Collections.Immutable"
+            return type.Namespace == "System.Collections.Immutable" 
                    && type.Name == "ImmutableArray`1";
         }
 
@@ -129,7 +129,7 @@ namespace KellermanSoftware.CompareNetObjects
                 return false;
 
             return (type.Namespace == "System.Collections.ObjectModel"
-                    && type.Name == "ReadOnlyCollection`1");
+                && type.Name == "ReadOnlyCollection`1");
         }
 
         /// <summary>
@@ -251,7 +251,7 @@ namespace KellermanSoftware.CompareNetObjects
                 return false;
 
             return type.GetTypeInfo().IsGenericType
-                   && type.GetTypeInfo().GetGenericTypeDefinition() == typeof(HashSet<>);
+                && type.GetTypeInfo().GetGenericTypeDefinition() == typeof(HashSet<>);
         }
 
         /// <summary>
@@ -395,6 +395,7 @@ namespace KellermanSoftware.CompareNetObjects
                    || type == typeof(Guid)
                    || type == typeof(Decimal)
                    || type.GetTypeInfo().IsEnum;
+
         }
 
         /// <summary>
@@ -556,5 +557,6 @@ namespace KellermanSoftware.CompareNetObjects
             return result;
         }
 #endif
+
     }
 }

--- a/Compare-NET-Objects/TypeHelper.cs
+++ b/Compare-NET-Objects/TypeHelper.cs
@@ -59,10 +59,10 @@ namespace KellermanSoftware.CompareNetObjects
         public static bool IsByteArray(Type type)
         {
             return IsIList(type) && (
-                typeof(IEnumerable<byte>).IsAssignableFrom(type) ||
-                typeof(IEnumerable<byte?>).IsAssignableFrom(type)
-                )
-                && type != typeof(sbyte[]);
+                                     typeof(IEnumerable<byte>).IsAssignableFrom(type) ||
+                                     typeof(IEnumerable<byte?>).IsAssignableFrom(type)
+                                 )
+                                 && type != typeof(sbyte[]);
         }
 
         /// <summary>
@@ -76,19 +76,19 @@ namespace KellermanSoftware.CompareNetObjects
                 return false;
 
             return !IsSimpleType(type)
-                && !IsTimespan(type)
-                && !IsDateTimeOffset(type)
-                && !IsEnum(type)
-                && !IsPointer(type)
-                && !IsStringBuilder(type)
-                && (IsClass(type)
-                    || IsInterface(type)
-                    || IsArray(type)
-                    || IsIDictionary(type)
-                    || IsIList(type)
-                    || IsStruct(type)
-                    || IsHashSet(type)
-                    );
+                   && !IsTimespan(type)
+                   && !IsDateTimeOffset(type)
+                   && !IsEnum(type)
+                   && !IsPointer(type)
+                   && !IsStringBuilder(type)
+                   && (IsClass(type)
+                       || IsInterface(type)
+                       || IsArray(type)
+                       || IsIDictionary(type)
+                       || IsIList(type)
+                       || IsStruct(type)
+                       || IsHashSet(type)
+                   );
         }
 
         /// <summary>
@@ -114,7 +114,7 @@ namespace KellermanSoftware.CompareNetObjects
             if (type == null)
                 return false;
 
-            return type.Namespace == "System.Collections.Immutable" 
+            return type.Namespace == "System.Collections.Immutable"
                    && type.Name == "ImmutableArray`1";
         }
 
@@ -129,7 +129,7 @@ namespace KellermanSoftware.CompareNetObjects
                 return false;
 
             return (type.Namespace == "System.Collections.ObjectModel"
-                && type.Name == "ReadOnlyCollection`1");
+                    && type.Name == "ReadOnlyCollection`1");
         }
 
         /// <summary>
@@ -251,7 +251,7 @@ namespace KellermanSoftware.CompareNetObjects
                 return false;
 
             return type.GetTypeInfo().IsGenericType
-                && type.GetTypeInfo().GetGenericTypeDefinition() == typeof(HashSet<>);
+                   && type.GetTypeInfo().GetGenericTypeDefinition() == typeof(HashSet<>);
         }
 
         /// <summary>
@@ -281,7 +281,7 @@ namespace KellermanSoftware.CompareNetObjects
 #else
             var toCheck = type.DeclaringType;
 #endif
-            return toCheck != null && toCheck == typeof(Enumerable);
+            return typeof(IEnumerable).IsAssignableFrom(type) && type != typeof(string) && type.Name != "ExpandoObject";
         }
 
         /// <summary>
@@ -395,7 +395,6 @@ namespace KellermanSoftware.CompareNetObjects
                    || type == typeof(Guid)
                    || type == typeof(Decimal)
                    || type.GetTypeInfo().IsEnum;
-
         }
 
         /// <summary>
@@ -557,6 +556,5 @@ namespace KellermanSoftware.CompareNetObjects
             return result;
         }
 #endif
-
     }
 }


### PR DESCRIPTION
Fixes #273 

About changes in existing tests: previous comparision was comparing the object properties, so you get differences reported for Count, Items.Count and the item that is different/missing.

Now, when strictly comparing, the only reported difference is Count, except when you ignore order. In that case, 2 differences are reported : Count and the item that is different/missing
