### PR TITLE
Compare Enums of different types, and compare Enums to strings

### DIFF
--- a/Compare-NET-Objects-Tests/CompareEnumTests.cs
+++ b/Compare-NET-Objects-Tests/CompareEnumTests.cs
@@ -181,6 +181,45 @@ namespace KellermanSoftware.CompareNetObjectsTests
 
             Assert.That(_compare.Compare(item1, item2).AreEqual, Is.False);
         }
+
+
+        [Test]
+        public void EnumsOfDifferentTypesTest()
+        {
+            Officer officer1 = new Officer();
+            officer1.Name = "Greg";
+            officer1.Type = Deck.Engineering;
+
+            Officer2 officer2 = new Officer2();
+            officer2.Name = "Greg";
+            officer2.Type = Deck2.Engineering;
+
+            _compare.Config.MaxDifferences = 2;
+            _compare.Config.IgnoreObjectTypes = true;
+
+            ComparisonResult result = _compare.Compare(officer1, officer2);
+
+            Assert.IsTrue(result.AreEqual, result.DifferencesString);
+        }
+
+        [Test]
+        public void EnumsWithOneStringTest()
+        {
+            Officer officer1 = new Officer();
+            officer1.Name = "Greg";
+            officer1.Type = Deck.Engineering;
+
+            Officer3 officer3 = new Officer3();
+            officer3.Name = "Greg";
+            officer3.Type = Deck2.Engineering.ToString();
+
+            _compare.Config.MaxDifferences = 2;
+            _compare.Config.IgnoreObjectTypes = true;
+
+            ComparisonResult result = _compare.Compare(officer1, officer3);
+            Assert.IsTrue(result.AreEqual, result.DifferencesString);
+        }
+
         #endregion
     }
 }

--- a/Compare-NET-Objects-Tests/TestClasses/Deck2.cs
+++ b/Compare-NET-Objects-Tests/TestClasses/Deck2.cs
@@ -1,0 +1,10 @@
+﻿namespace KellermanSoftware.CompareNetObjectsTests.TestClasses;
+
+public enum Deck2
+{
+    Navigation,
+    Engineering,
+    SickBay,
+    AstroPhysics,
+    Control
+}

--- a/Compare-NET-Objects-Tests/TestClasses/Officer2.cs
+++ b/Compare-NET-Objects-Tests/TestClasses/Officer2.cs
@@ -1,0 +1,8 @@
+﻿namespace KellermanSoftware.CompareNetObjectsTests.TestClasses;
+
+public class Officer2
+{
+    public int ID { get; set; }
+    public string Name { get; set; }
+    public Deck2 Type { get; set; }
+}

--- a/Compare-NET-Objects-Tests/TestClasses/Officer3.cs
+++ b/Compare-NET-Objects-Tests/TestClasses/Officer3.cs
@@ -1,0 +1,8 @@
+﻿namespace KellermanSoftware.CompareNetObjectsTests.TestClasses;
+
+public class Officer3
+{
+    public int ID { get; set; }
+    public string Name { get; set; }
+    public string Type { get; set; }
+}

--- a/Compare-NET-Objects/RootComparerFactory.cs
+++ b/Compare-NET-Objects/RootComparerFactory.cs
@@ -69,8 +69,8 @@ namespace KellermanSoftware.CompareNetObjects
             _rootComparer.TypeComparers.Add(new ClassComparer(_rootComparer));
             _rootComparer.TypeComparers.Add(new DateTimeOffSetComparer(_rootComparer));
             _rootComparer.TypeComparers.Add(new TimespanComparer(_rootComparer));
-            _rootComparer.TypeComparers.Add(new StructComparer(_rootComparer));
             _rootComparer.TypeComparers.Add(new EnumComparer(_rootComparer));
+            _rootComparer.TypeComparers.Add(new StructComparer(_rootComparer));
             return _rootComparer;
         }
         #endregion

--- a/Compare-NET-Objects/TypeComparers/EnumComparer.cs
+++ b/Compare-NET-Objects/TypeComparers/EnumComparer.cs
@@ -23,7 +23,7 @@ namespace KellermanSoftware.CompareNetObjects.TypeComparers
         /// <returns></returns>
         public override bool IsTypeMatch(Type type1, Type type2)
         {
-            return TypeHelper.IsEnum(type1) && TypeHelper.IsEnum(type2);
+            return TypeHelper.IsEnum(type1) || TypeHelper.IsEnum(type2);
         }
 
         /// <summary>
@@ -31,7 +31,7 @@ namespace KellermanSoftware.CompareNetObjects.TypeComparers
         /// </summary>
         public override void CompareType(CompareParms parms)
         {
-            if (parms.Object1.ToString() != parms.Object2.ToString())
+            if (parms.Object1?.ToString() != parms.Object2?.ToString())
             {
                 AddDifference(parms);
             }

--- a/Compare-NET-Objects/TypeHelper.cs
+++ b/Compare-NET-Objects/TypeHelper.cs
@@ -63,7 +63,7 @@ namespace KellermanSoftware.CompareNetObjects
                 typeof(IEnumerable<byte?>).IsAssignableFrom(type)
                 )
                 && type != typeof(sbyte[]);
-}
+        }
 
         /// <summary>
         /// Returns true if the type can have children

--- a/Compare-NET-Objects/TypeHelper.cs
+++ b/Compare-NET-Objects/TypeHelper.cs
@@ -59,11 +59,11 @@ namespace KellermanSoftware.CompareNetObjects
         public static bool IsByteArray(Type type)
         {
             return IsIList(type) && (
-                                     typeof(IEnumerable<byte>).IsAssignableFrom(type) ||
-                                     typeof(IEnumerable<byte?>).IsAssignableFrom(type)
-                                 )
-                                 && type != typeof(sbyte[]);
-        }
+                typeof(IEnumerable<byte>).IsAssignableFrom(type) ||
+                typeof(IEnumerable<byte?>).IsAssignableFrom(type)
+                )
+                && type != typeof(sbyte[]);
+}
 
         /// <summary>
         /// Returns true if the type can have children
@@ -76,19 +76,19 @@ namespace KellermanSoftware.CompareNetObjects
                 return false;
 
             return !IsSimpleType(type)
-                   && !IsTimespan(type)
-                   && !IsDateTimeOffset(type)
-                   && !IsEnum(type)
-                   && !IsPointer(type)
-                   && !IsStringBuilder(type)
-                   && (IsClass(type)
-                       || IsInterface(type)
-                       || IsArray(type)
-                       || IsIDictionary(type)
-                       || IsIList(type)
-                       || IsStruct(type)
-                       || IsHashSet(type)
-                   );
+                && !IsTimespan(type)
+                && !IsDateTimeOffset(type)
+                && !IsEnum(type)
+                && !IsPointer(type)
+                && !IsStringBuilder(type)
+                && (IsClass(type)
+                    || IsInterface(type)
+                    || IsArray(type)
+                    || IsIDictionary(type)
+                    || IsIList(type)
+                    || IsStruct(type)
+                    || IsHashSet(type)
+                    );
         }
 
         /// <summary>
@@ -114,7 +114,7 @@ namespace KellermanSoftware.CompareNetObjects
             if (type == null)
                 return false;
 
-            return type.Namespace == "System.Collections.Immutable"
+            return type.Namespace == "System.Collections.Immutable" 
                    && type.Name == "ImmutableArray`1";
         }
 
@@ -129,7 +129,7 @@ namespace KellermanSoftware.CompareNetObjects
                 return false;
 
             return (type.Namespace == "System.Collections.ObjectModel"
-                    && type.Name == "ReadOnlyCollection`1");
+                && type.Name == "ReadOnlyCollection`1");
         }
 
         /// <summary>
@@ -256,7 +256,7 @@ namespace KellermanSoftware.CompareNetObjects
                 return false;
 
             return type.GetTypeInfo().IsGenericType
-                   && type.GetTypeInfo().GetGenericTypeDefinition() == typeof(HashSet<>);
+                && type.GetTypeInfo().GetGenericTypeDefinition() == typeof(HashSet<>);
         }
 
         /// <summary>

--- a/Compare-NET-Objects/TypeHelper.cs
+++ b/Compare-NET-Objects/TypeHelper.cs
@@ -59,10 +59,10 @@ namespace KellermanSoftware.CompareNetObjects
         public static bool IsByteArray(Type type)
         {
             return IsIList(type) && (
-                typeof(IEnumerable<byte>).IsAssignableFrom(type) ||
-                typeof(IEnumerable<byte?>).IsAssignableFrom(type)
-                )
-                && type != typeof(sbyte[]);
+                                     typeof(IEnumerable<byte>).IsAssignableFrom(type) ||
+                                     typeof(IEnumerable<byte?>).IsAssignableFrom(type)
+                                 )
+                                 && type != typeof(sbyte[]);
         }
 
         /// <summary>
@@ -76,19 +76,19 @@ namespace KellermanSoftware.CompareNetObjects
                 return false;
 
             return !IsSimpleType(type)
-                && !IsTimespan(type)
-                && !IsDateTimeOffset(type)
-                && !IsEnum(type)
-                && !IsPointer(type)
-                && !IsStringBuilder(type)
-                && (IsClass(type)
-                    || IsInterface(type)
-                    || IsArray(type)
-                    || IsIDictionary(type)
-                    || IsIList(type)
-                    || IsStruct(type)
-                    || IsHashSet(type)
-                    );
+                   && !IsTimespan(type)
+                   && !IsDateTimeOffset(type)
+                   && !IsEnum(type)
+                   && !IsPointer(type)
+                   && !IsStringBuilder(type)
+                   && (IsClass(type)
+                       || IsInterface(type)
+                       || IsArray(type)
+                       || IsIDictionary(type)
+                       || IsIList(type)
+                       || IsStruct(type)
+                       || IsHashSet(type)
+                   );
         }
 
         /// <summary>
@@ -114,7 +114,7 @@ namespace KellermanSoftware.CompareNetObjects
             if (type == null)
                 return false;
 
-            return type.Namespace == "System.Collections.Immutable" 
+            return type.Namespace == "System.Collections.Immutable"
                    && type.Name == "ImmutableArray`1";
         }
 
@@ -129,7 +129,7 @@ namespace KellermanSoftware.CompareNetObjects
                 return false;
 
             return (type.Namespace == "System.Collections.ObjectModel"
-                && type.Name == "ReadOnlyCollection`1");
+                    && type.Name == "ReadOnlyCollection`1");
         }
 
         /// <summary>
@@ -142,7 +142,7 @@ namespace KellermanSoftware.CompareNetObjects
             if (type == null)
                 return false;
 
-            return type.GetTypeInfo().IsValueType && !IsSimpleType(type) && !IsImmutableArray(type);
+            return type.GetTypeInfo().IsValueType && !IsSimpleType(type) && !IsImmutableArray(type) || !IsEnum((type));
         }
 
         /// <summary>
@@ -224,6 +224,11 @@ namespace KellermanSoftware.CompareNetObjects
             if (type == null)
                 return false;
 
+            if (type.GetTypeInfo().IsGenericType && type.GetTypeInfo().GetGenericTypeDefinition() == typeof(Nullable<>))
+            {
+                type = Nullable.GetUnderlyingType(type);
+            }
+
             return type.GetTypeInfo().IsEnum;
         }
 
@@ -251,7 +256,7 @@ namespace KellermanSoftware.CompareNetObjects
                 return false;
 
             return type.GetTypeInfo().IsGenericType
-                && type.GetTypeInfo().GetGenericTypeDefinition() == typeof(HashSet<>);
+                   && type.GetTypeInfo().GetGenericTypeDefinition() == typeof(HashSet<>);
         }
 
         /// <summary>
@@ -393,9 +398,7 @@ namespace KellermanSoftware.CompareNetObjects
                    || type == typeof(DateTime)
                    || type == typeof(string)
                    || type == typeof(Guid)
-                   || type == typeof(Decimal)
-                   || type.GetTypeInfo().IsEnum;
-
+                   || type == typeof(Decimal);
         }
 
         /// <summary>
@@ -557,6 +560,5 @@ namespace KellermanSoftware.CompareNetObjects
             return result;
         }
 #endif
-
     }
 }


### PR DESCRIPTION
Compares enums of different types & to strings
Fixes #287

I don't think `EnumComparer` was ever used, as enums are caught by `IsPrimitive`, and `StructComparer` is also catching enums (it seems that the framework considers enums as structs)

Few notes :
* EnumComparer's `IsTypeMatch` could be "safer" if we check for `IsEnum` & String, but I'm not sure this is necessary. Thoughts ?
* In `RootComparerFactory` I had to move Enum up, as an enum is considered a struct by framework
* I had an issue handling nullable enums, I'm not sure I did it the "right" way