### PR TITLE
Disable GetTypeInfo  compilation for all versions of .NET

### DIFF
--- a/Compare-NET-Objects-Tests/GetTypeInfoTests.cs
+++ b/Compare-NET-Objects-Tests/GetTypeInfoTests.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using KellermanSoftware.CompareNetObjects;
+using KellermanSoftware.CompareNetObjectsTests.Attributes;
+using KellermanSoftware.CompareNetObjectsTests.TestClasses;
+using NUnit.Framework;
+
+namespace KellermanSoftware.CompareNetObjectsTests
+{
+    [TestFixture]
+    public class GetTypeInfoTests
+    {
+        [Test]
+        public void EnsureCallingGetTypeInfoCompiles()
+        {
+            _ = typeof(AlPeTests).GetTypeInfo();
+        }
+    }
+}

--- a/Compare-NET-Objects/TypeBackwardsCompatibilityExtensions.cs
+++ b/Compare-NET-Objects/TypeBackwardsCompatibilityExtensions.cs
@@ -2,7 +2,7 @@
 
 namespace KellermanSoftware.CompareNetObjects
 {
-#if !NETSTANDARD
+#if !NETSTANDARD && !NET
     /// <summary>
     /// Extensions for Type to provide backward compatibility between latest and older .net Framework APIs.
     /// </summary>

--- a/Compare-NET-Objects/TypeBackwardsCompatibilityExtensions.cs
+++ b/Compare-NET-Objects/TypeBackwardsCompatibilityExtensions.cs
@@ -2,7 +2,7 @@
 
 namespace KellermanSoftware.CompareNetObjects
 {
-#if !NETSTANDARD /*&& !NET && !NET46_OR_GREATER*/
+#if !NETSTANDARD
     /// <summary>
     /// Extensions for Type to provide backward compatibility between latest and older .net Framework APIs.
     /// </summary>

--- a/Compare-NET-Objects/TypeBackwardsCompatibilityExtensions.cs
+++ b/Compare-NET-Objects/TypeBackwardsCompatibilityExtensions.cs
@@ -2,7 +2,7 @@
 
 namespace KellermanSoftware.CompareNetObjects
 {
-#if !NETSTANDARD && !NET && !NET46
+#if !NETSTANDARD && !NET && !NET46_OR_GREATER
     /// <summary>
     /// Extensions for Type to provide backward compatibility between latest and older .net Framework APIs.
     /// </summary>

--- a/Compare-NET-Objects/TypeBackwardsCompatibilityExtensions.cs
+++ b/Compare-NET-Objects/TypeBackwardsCompatibilityExtensions.cs
@@ -2,7 +2,7 @@
 
 namespace KellermanSoftware.CompareNetObjects
 {
-#if !NETSTANDARD && !NET
+#if !NETSTANDARD && !NET && !NET46
     /// <summary>
     /// Extensions for Type to provide backward compatibility between latest and older .net Framework APIs.
     /// </summary>

--- a/Compare-NET-Objects/TypeBackwardsCompatibilityExtensions.cs
+++ b/Compare-NET-Objects/TypeBackwardsCompatibilityExtensions.cs
@@ -2,7 +2,7 @@
 
 namespace KellermanSoftware.CompareNetObjects
 {
-#if !NETSTANDARD && !NET && !NET46_OR_GREATER
+#if !NETSTANDARD /*&& !NET && !NET46_OR_GREATER*/
     /// <summary>
     /// Extensions for Type to provide backward compatibility between latest and older .net Framework APIs.
     /// </summary>


### PR DESCRIPTION
Hides `public static Type GetTypeInfo(this Type type)` from .NET 6 and 7