### PR TITLE
Add support for .NET 8

### DIFF
--- a/Compare-NET-Objects-Tests/Compare-NET-Objects-Tests.csproj
+++ b/Compare-NET-Objects-Tests/Compare-NET-Objects-Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0;net7.0;net8.0</TargetFrameworks>
     <AssemblyName>Compare-NET-Objects-Tests</AssemblyName>
     <RootNamespace>KellermanSoftware.CompareNetObjectsTests</RootNamespace>
     <IsPackable>false</IsPackable>

--- a/Compare-NET-Objects-Tests/Compare-NET-Objects-Tests.csproj
+++ b/Compare-NET-Objects-Tests/Compare-NET-Objects-Tests.csproj
@@ -1,10 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <AssemblyName>Compare-NET-Objects-Tests</AssemblyName>
     <RootNamespace>KellermanSoftware.CompareNetObjectsTests</RootNamespace>
     <IsPackable>false</IsPackable>
+
+    <!-- Binary Formatter should not be used any more. If this setting is omitted, the compile error SYSLIB0011 is raised,
+         see https://learn.microsoft.com/en-us/dotnet/core/compatibility/serialization/7.0/binaryformatter-apis-produce-errors#recommended-action -->
+    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 
   <ItemGroup>
@@ -36,9 +40,12 @@
     <DefineConstants>$(DefineConstants);NET6_0;NETFULL</DefineConstants>
   </PropertyGroup>
 
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net7.0'">
+	<PropertyGroup Condition=" '$(TargetFramework)' == 'net7.0'">
     <DefineConstants>$(DefineConstants);NET7_0;NETFULL</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+    <DefineConstants>$(DefineConstants);NET8_0;NETFULL</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition="!$(IsNetCore)">

--- a/Compare-NET-Objects/Compare-NET-Objects.csproj
+++ b/Compare-NET-Objects/Compare-NET-Objects.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>Kellerman-Serialization</AssemblyTitle>
     <AssemblyCompany>Kellerman Software</AssemblyCompany>
     <AssemblyProduct>Kellerman-Serialization</AssemblyProduct>
-    <TargetFrameworks>net40;net45;net451;net452;net46;net47;net471;net472;net48;net6.0;net7.0;netstandard1.3;netstandard2.0;netstandard2.1;</TargetFrameworks>
+    <TargetFrameworks>net40;net45;net451;net452;net46;net47;net471;net472;net48;net6.0;net7.0;net8.0;netstandard1.3;netstandard2.0;netstandard2.1;</TargetFrameworks>
     <AssemblyName>KellermanSoftware.Compare-NET-Objects</AssemblyName>
     <RootNamespace>KellermanSoftware.CompareNetObjects</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -100,9 +100,12 @@
     <DefineConstants>$(DefineConstants);NET6_0;NETFULL</DefineConstants>
   </PropertyGroup>
 
-
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net7.0'">
     <DefineConstants>$(DefineConstants);NET7_0;NETFULL</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+    <DefineConstants>$(DefineConstants);NET8_0;NETFULL</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -150,6 +153,11 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
-    <PackageReference Include="System.Configuration.Configurationmanager" Version="6.0.0" />
+    <PackageReference Include="System.Configuration.Configurationmanager" Version="7.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="System.Configuration.Configurationmanager" Version="8.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Hi!

This PR handles the issue discussed in #306 without introducing a new API surface.

Currently, the package doesn't work with .NET 8 since the `FontComparer` is used, which has a dependency to `System.Drawing`. For .NET 8, we need to add a `PackageReference` to [`System.Drawing.Common`](https://www.nuget.org/packages/System.Drawing.Common/).

I added the `net8.0` target framework to the library and the target frameworks `net7.0` and `net8.0` to the unit test project.

Additionally, I had to add `EnableUnsafeBinaryFormatterSerialization` in the test project, since [it is not recommended to use the `BinaryFormatter` any more](https://learn.microsoft.com/en-us/dotnet/core/compatibility/serialization/7.0/binaryformatter-apis-produce-errors).