### PR TITLE
Problem solved: Dictionary with Enum as Key

### DIFF
--- a/Compare-NET-Objects/TypeComparers/DictionaryComparer.cs
+++ b/Compare-NET-Objects/TypeComparers/DictionaryComparer.cs
@@ -93,7 +93,7 @@ namespace KellermanSoftware.CompareNetObjects.TypeComparers
                     var enumerator1 = ((IDictionary) parms.Object1).GetEnumerator();
                     enumerator1.MoveNext();
                     shouldCompareByKeys =
-                        enumerator1.Key != null && TypeHelper.IsSimpleType(enumerator1.Key.GetType());
+                        enumerator1.Key != null && (TypeHelper.IsSimpleType(enumerator1.Key.GetType()) || TypeHelper.IsEnum(enumerator1.Key.GetType()));
                 }
             }
 


### PR DESCRIPTION
Comparing a Dictionary with Enum as key the PropertyPath will not result in something like [EnumName].Value.MyProperty instead it will result in Value.MyProperty because ShouldCompareByKeys will return false. Enum is not a simple type even if it is a integer or similar.